### PR TITLE
 APPMESH_RESOURCE_ARN is not deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ The AppNet Agent supports using a few environment variable to alter some aspects
 
 ### Deprecated
 
-* `APPMESH_RESOURCE_ARN`
 * `APPMESH_RESOURCE_NAME`
 * `APPMESH_VIRTUAL_NODE_NAME`
 


### PR DESCRIPTION
*Description of changes:*

Fix the inadvertent inclusion of APPMESH_RESOURCE_ARN in the deprecated variables list

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
