### PR TITLE
Add option to override reloadable_features.sanitize_original_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ These environment variables offer controls for the bootstrap config generation f
 |`APPMESH_SET_TRACING_DECISION`	|<true &#124; false>	|Controls whether Envoy modifies the `x-request-id` header appearing in a request from a client	|TRUE	|
 |`ENVOY_NO_EXTENSION_LOOKUP_BY_NAME`	|<true &#124; false>	|Controls whether Envoy needs type URL to lookup extensions regardless of the name field. If the type URL is missing it will reject (NACK) the configuration	|true	|
 |`ENVOY_ENABLE_TCP_POOL_IDLE_TIMEOUT`	|<true &#124; false>	|Controls whether the `idle_timeout` protocol options feature is enabled for TCP upstreams. If not configured the default `idle_timeout` is 10 minutes. Set this environment variable to `false` to disable `idle_timeout` option.	|true	|
+|`ENVOY_SANITIZE_ORIGINAL_PATH`	|<true &#124; false>	|Controls whether to sanitize `x-envoy-original-path` coming from an untrusted users. Set this environment variable to `false` to not sanitize `x-envoy-original-path` header coming from untrusted users.	|true	|
 |`APPMESH_SDS_SOCKET_PATH`	|/path/to/socket	|Unix Domain Socket for SDS Based TLS.	|	|
 |`APPMESH_PREVIEW`	|<0 &#124; 1>	|Enables the App Mesh Preview Endpoint	|	|
 |`APPMESH_DUALSTACK_ENDPOINT`	|<0 &#124; 1>	|Enables the App Mesh Dual-Stack Endpoint	|	|

--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -607,6 +607,7 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.tcp_pool_idle_timeout: true
+      envoy.reloadable_features.sanitize_original_path: true
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}
@@ -629,6 +630,7 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: false
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.tcp_pool_idle_timeout: true
+      envoy.reloadable_features.sanitize_original_path: true
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}
@@ -651,6 +653,7 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: false
       envoy.reloadable_features.tcp_pool_idle_timeout: true
+      envoy.reloadable_features.sanitize_original_path: true
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}
@@ -673,6 +676,30 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.tcp_pool_idle_timeout: false
+      envoy.reloadable_features.sanitize_original_path: true
+      re2.max_program_size.error_level: 1000
+  - name: "admin_layer"
+    adminLayer: {}
+`)
+}
+
+func TestBuildLayeredRuntime_DontSanitizeOriginalPath(t *testing.T) {
+	setup()
+	os.Setenv("ENVOY_SANITIZE_ORIGINAL_PATH", "false")
+	defer os.Unsetenv("ENVOY_SANITIZE_ORIGINAL_PATH")
+	rt, err := buildLayeredRuntime()
+	if err != nil {
+		t.Error(err)
+	}
+	checkMessage(t, rt, `
+layers:
+  - name: "static_layer_0"
+    staticLayer:
+      envoy.features.enable_all_deprecated_features: true
+      envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
+      envoy.reloadable_features.no_extension_lookup_by_name: true
+      envoy.reloadable_features.tcp_pool_idle_timeout: true
+      envoy.reloadable_features.sanitize_original_path: false
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}


### PR DESCRIPTION
### Summary
Add option to override ` envoy reloadable_features.sanitize_original_path` if needed via env variable `ENVOY_SANITIZE_ORIGINAL_PATH`. By default this will be true. Allowed values are `true` or `false`.


### Testing
`make test`

New tests cover the changes: yes

### Description for the changelog
Expose option to override the default value of `reloadable_features.sanitize_original_path` via `ENVOY_SANITIZE_ORIGINAL_PATH` environment variable.  Default is true.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
