### PR TITLE
Support fips mode in US GovCloud regions

### DIFF
--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -272,6 +272,21 @@ func TestGetRegionalXdsEndpoint_BoringSSL_Fips(t *testing.T) {
 	assertEquals(t, "appmesh-envoy-management-fips.us-west-2.amazonaws.com:443", *v)
 }
 
+func TestGetGovCloudRegionalXdsEndpoint_AWS_LC_Fips(t *testing.T) {
+	setup()
+	v, err := getRegionalXdsEndpoint("us-gov-east-1", newMockEnvoyCLI("AWS-LC-FIPS", nil))
+	if err != nil {
+		t.Error(err)
+	}
+	assertEquals(t, "appmesh-envoy-management.us-gov-east-1.amazonaws.com:443", *v)
+}
+
+func TestGetGovCloudRegionalXdsEndpoint_BoringSSL(t *testing.T) {
+	setup()
+	v, err := getRegionalXdsEndpoint("us-gov-west-1", newMockEnvoyCLI("BoringSSL", nil))
+	assertError(t, v, err)
+}
+
 func TestGetRegionalXdsEndpoint_Fips_Dualstack(t *testing.T) {
 	setup()
 	os.Setenv("APPMESH_DUALSTACK_ENDPOINT", "1")
@@ -281,6 +296,17 @@ func TestGetRegionalXdsEndpoint_Fips_Dualstack(t *testing.T) {
 		t.Error(err)
 	}
 	assertEquals(t, "appmesh-envoy-management-fips.us-west-2.api.aws:443", *v)
+}
+
+func TestGetGovCloudRegionalXdsEndpoint_Fips_Dualstack(t *testing.T) {
+	setup()
+	os.Setenv("APPMESH_DUALSTACK_ENDPOINT", "1")
+	defer os.Unsetenv("APPMESH_DUALSTACK_ENDPOINT")
+	v, err := getRegionalXdsEndpoint("us-gov-west-1", newMockEnvoyCLI("AWS-LC-FIPS", nil))
+	if err != nil {
+		t.Error(err)
+	}
+	assertEquals(t, "appmesh-envoy-management.us-gov-west-1.api.aws:443", *v)
 }
 
 func TestGetRegionalXdsEndpoint_Preview_Fips_Dualstack(t *testing.T) {


### PR DESCRIPTION
In US GovCloud regions the Envoy image has to be fips compatible. However, unlike US & CA commercial regions the FIPS xDS endpoint for AppMesh in US GovCloud will not have -fips suffix for time being.
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Reach out to the appropriate endpoint in GovCloud region. If non-FIPS image is used in GovCloud it will return error. Meanwhile this can be overridden by specifying `APPMESH_XDS_ENDPOINT`.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
Please ensure unit and integration tests pass (on at least one platform) before opening the pull request.
Once you open the pull request, there will be several automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it.
-->

New tests cover the changes: yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Support fips mode in US GovCloud regions

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
