### PR TITLE
Include static runtime flag into bootstrap metadata

### DIFF
--- a/agent/envoy_bootstrap/envoy_bootstrap.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap.go
@@ -69,6 +69,7 @@ var (
 )
 
 const (
+	runtimeMetadataNamespace    = "aws.appmesh.static_runtime"
 	staticResourcesKey          = "staticResources"
 	tracingKey                  = "tracing"
 	statsConfigKey              = "statsConfig"
@@ -1387,6 +1388,12 @@ func convertToYAML(b *boot.Bootstrap, fileUtil FileUtil) (string, error) {
 
 func buildMetadataForNode() (*structpb.Struct, error) {
 	metadata := make(map[string]interface{})
+
+	if runtimeConfig, err := getRuntimeConfigLayer0(); err != nil {
+		log.Warnf("Could not collect static runtime info: %s", err)
+	} else {
+		metadata[runtimeMetadataNamespace] = runtimeConfig
+	}
 
 	interfaceInfo, err := netinfo.BuildMapWithInterfaceInfo()
 	if err != nil {

--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -660,6 +660,56 @@ metadata:
 `)
 }
 
+func TestBuildNodeMetadata_StaticRuntimeMappingDefault(t *testing.T) {
+	setup()
+	metadata, err := buildMetadataForNode()
+	assert.Nil(t, err)
+	// ignore metadata: aws.appmesh.platformInfo & aws.appmesh.task.interfaces
+	checkMessageSupersetMatch(t, buildNode("id", "cluster", metadata), `
+id: id
+cluster: cluster
+metadata:
+  aws.appmesh.static_runtime:
+    envoy.features.enable_all_deprecated_features: true
+    envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
+    envoy.reloadable_features.no_extension_lookup_by_name: true
+    envoy.reloadable_features.tcp_pool_idle_timeout: true
+    envoy.reloadable_features.sanitize_original_path: true
+    envoy.reloadable_features.successful_active_health_check_uneject_host: false
+    re2.max_program_size.error_level: 1000
+`)
+}
+
+func TestBuildNodeMetadata_StaticRuntimeMappingDefaultOverridden(t *testing.T) {
+	setup()
+	os.Setenv("APPMESH_SET_TRACING_DECISION", "false")
+	defer os.Unsetenv("APPMESH_SET_TRACING_DECISION")
+	os.Setenv("ENVOY_NO_EXTENSION_LOOKUP_BY_NAME", "false")
+	defer os.Unsetenv("ENVOY_NO_EXTENSION_LOOKUP_BY_NAME")
+	os.Setenv("ENVOY_ENABLE_TCP_POOL_IDLE_TIMEOUT", "false")
+	defer os.Unsetenv("ENVOY_ENABLE_TCP_POOL_IDLE_TIMEOUT")
+	os.Setenv("ENVOY_SANITIZE_ORIGINAL_PATH", "false")
+	defer os.Unsetenv("ENVOY_SANITIZE_ORIGINAL_PATH")
+	os.Setenv("ENVOY_ACTIVE_HEALTH_CHECK_UNEJECT_HOST", "true")
+	defer os.Unsetenv("ENVOY_ACTIVE_HEALTH_CHECK_UNEJECT_HOST")
+	metadata, err := buildMetadataForNode()
+	assert.Nil(t, err)
+	// ignore metadata: aws.appmesh.platformInfo & aws.appmesh.task.interfaces
+	checkMessageSupersetMatch(t, buildNode("id", "cluster", metadata), `
+id: id
+cluster: cluster
+metadata:
+  aws.appmesh.static_runtime:
+    envoy.features.enable_all_deprecated_features: true
+    envoy.reloadable_features.http_set_tracing_decision_in_request_id: false
+    envoy.reloadable_features.no_extension_lookup_by_name: false
+    envoy.reloadable_features.tcp_pool_idle_timeout: false
+    envoy.reloadable_features.sanitize_original_path: false
+    envoy.reloadable_features.successful_active_health_check_uneject_host: true
+    re2.max_program_size.error_level: 1000
+`)
+}
+
 func TestBuildLayeredRuntime(t *testing.T) {
 	setup()
 	rt, err := buildLayeredRuntime()


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Include the static runtime config into bootstrap metadata, so that control plane can get feedback if any runtime config is overridden

### Implementation details
<!-- How are the changes implemented? -->
Just call static runtime config generator again inside metadata generator

### Testing
<!-- How was this tested? -->
cd agent; make build
<!--
Note for external contributors:
Please ensure unit and integration tests pass (on at least one platform) before opening the pull request.
Once you open the pull request, there will be several automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it.
-->

New tests cover the changes: yes

### Description for the changelog
Include static runtime flag into bootstrap metadata

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
