### PR TITLE
Change SC agent health compute logic to health flip

### DIFF
--- a/agent/healthcheck/health_check_test.go
+++ b/agent/healthcheck/health_check_test.go
@@ -146,12 +146,11 @@ func TestHealthUpdater(t *testing.T) {
 }
 
 func TestComputeHealthCheck_EnvoyLive_Healthy(t *testing.T) {
-	statusSinceTime := time.Now()
 	healthStatus := HealthStatus{
-		HealthStatus:                          "",
-		EnvoyState:                            "LIVE",
-		ManagementServerConnectionStatus:      "CONNECTED",
-		ManagementServerDisconnectedTimestamp: &statusSinceTime,
+		HealthStatus:                     "",
+		EnvoyState:                       "LIVE",
+		ManagementServerConnectionStatus: "CONNECTED",
+		HealthStatusFlipCount:            0,
 	}
 	var agentConfig config.AgentConfig
 	agentConfig.SetDefaults()
@@ -162,12 +161,11 @@ func TestComputeHealthCheck_EnvoyLive_Healthy(t *testing.T) {
 }
 
 func TestComputeHealthCheck_EnvoyUnreachable_UnHealthy(t *testing.T) {
-	statusSinceTime := time.Now()
 	healthStatus := HealthStatus{
-		HealthStatus:                          "",
-		EnvoyState:                            "UNREACHABLE",
-		ManagementServerConnectionStatus:      "CONNECTED",
-		ManagementServerDisconnectedTimestamp: &statusSinceTime,
+		HealthStatus:                     "",
+		EnvoyState:                       "UNREACHABLE",
+		ManagementServerConnectionStatus: "CONNECTED",
+		HealthStatusFlipCount:            0,
 	}
 	var agentConfig config.AgentConfig
 	agentConfig.SetDefaults()
@@ -178,12 +176,11 @@ func TestComputeHealthCheck_EnvoyUnreachable_UnHealthy(t *testing.T) {
 }
 
 func TestComputeHealthCheck_EnvoyUnInitialized_UnHealthy(t *testing.T) {
-	statusSinceTime := time.Now()
 	healthStatus := HealthStatus{
-		HealthStatus:                          "",
-		EnvoyState:                            "INITIALIZING",
-		ManagementServerConnectionStatus:      "CONNECTED",
-		ManagementServerDisconnectedTimestamp: &statusSinceTime,
+		HealthStatus:                     "",
+		EnvoyState:                       "INITIALIZING",
+		ManagementServerConnectionStatus: "CONNECTED",
+		HealthStatusFlipCount:            0,
 	}
 	var agentConfig config.AgentConfig
 	agentConfig.SetDefaults()
@@ -194,12 +191,11 @@ func TestComputeHealthCheck_EnvoyUnInitialized_UnHealthy(t *testing.T) {
 }
 
 func TestComputeHealthCheck_EnvoyDisconnected_Healthy(t *testing.T) {
-	statusSinceTime := time.Now().Add(-time.Minute * 30)
 	healthStatus := HealthStatus{
-		HealthStatus:                          "",
-		EnvoyState:                            "LIVE",
-		ManagementServerConnectionStatus:      "NOT_CONNECTED",
-		ManagementServerDisconnectedTimestamp: &statusSinceTime,
+		HealthStatus:                     "",
+		EnvoyState:                       "LIVE",
+		ManagementServerConnectionStatus: "NOT_CONNECTED",
+		HealthStatusFlipCount:            0,
 	}
 	var agentConfig config.AgentConfig
 	agentConfig.SetDefaults()
@@ -212,12 +208,11 @@ func TestComputeHealthCheck_EnvoyDisconnected_Healthy(t *testing.T) {
 func TestComputeHealthCheck_EnvoyDisconnected_UnHealthy(t *testing.T) {
 	os.Setenv("APPNET_ENABLE_RELAY_MODE_FOR_XDS", "0")
 	defer os.Unsetenv("APPNET_ENABLE_RELAY_MODE_FOR_XDS")
-	statusSinceTime := time.Now().Add(-time.Hour * 24 * 30)
 	healthStatus := HealthStatus{
-		HealthStatus:                          "",
-		EnvoyState:                            "LIVE",
-		ManagementServerConnectionStatus:      "NOT_CONNECTED",
-		ManagementServerDisconnectedTimestamp: &statusSinceTime,
+		HealthStatus:                     "",
+		EnvoyState:                       "LIVE",
+		ManagementServerConnectionStatus: "NOT_CONNECTED",
+		HealthStatusFlipCount:            5,
 	}
 	var agentConfig config.AgentConfig
 	agentConfig.SetDefaults()
@@ -230,12 +225,11 @@ func TestComputeHealthCheck_EnvoyDisconnected_UnHealthy(t *testing.T) {
 func TestComputeHealthCheck_EnvoyDisconnected_RelayMode_Healthy(t *testing.T) {
 	os.Setenv("APPNET_ENABLE_RELAY_MODE_FOR_XDS", "1")
 	defer os.Unsetenv("APPNET_ENABLE_RELAY_MODE_FOR_XDS")
-	statusSinceTime := time.Now().Add(-time.Hour * 24 * 30)
 	healthStatus := HealthStatus{
-		HealthStatus:                          "",
-		EnvoyState:                            "LIVE",
-		ManagementServerConnectionStatus:      "NOT_CONNECTED",
-		ManagementServerDisconnectedTimestamp: &statusSinceTime,
+		HealthStatus:                     "",
+		EnvoyState:                       "LIVE",
+		ManagementServerConnectionStatus: "NOT_CONNECTED",
+		HealthStatusFlipCount:            0,
 	}
 	var agentConfig config.AgentConfig
 	agentConfig.SetDefaults()
@@ -246,13 +240,12 @@ func TestComputeHealthCheck_EnvoyDisconnected_RelayMode_Healthy(t *testing.T) {
 }
 
 func TestComputeHealthCheck_InitialConfigUpdateFailed(t *testing.T) {
-	statusSinceTime := time.Now().Add(-time.Hour * 24 * 30)
 	healthStatus := HealthStatus{
-		HealthStatus:                          "",
-		EnvoyState:                            "LIVE",
-		ManagementServerConnectionStatus:      "CONNECTED",
-		ManagementServerDisconnectedTimestamp: &statusSinceTime,
-		InitialConfigUpdateStatus:             "UPDATE_FAILED",
+		HealthStatus:                     "",
+		EnvoyState:                       "LIVE",
+		ManagementServerConnectionStatus: "CONNECTED",
+		InitialConfigUpdateStatus:        "UPDATE_FAILED",
+		HealthStatusFlipCount:            0,
 	}
 	var agentConfig config.AgentConfig
 	agentConfig.SetDefaults()
@@ -263,13 +256,12 @@ func TestComputeHealthCheck_InitialConfigUpdateFailed(t *testing.T) {
 }
 
 func TestComputeHealthCheck_InitialConfigUpdateSuccessful(t *testing.T) {
-	statusSinceTime := time.Now().Add(-time.Hour * 24 * 30)
 	healthStatus := HealthStatus{
-		HealthStatus:                          "",
-		EnvoyState:                            "LIVE",
-		ManagementServerConnectionStatus:      "CONNECTED",
-		ManagementServerDisconnectedTimestamp: &statusSinceTime,
-		InitialConfigUpdateStatus:             "UPDATE_SUCCESSFUL",
+		HealthStatus:                     "",
+		EnvoyState:                       "LIVE",
+		ManagementServerConnectionStatus: "CONNECTED",
+		InitialConfigUpdateStatus:        "UPDATE_SUCCESSFUL",
+		HealthStatusFlipCount:            0,
 	}
 	var agentConfig config.AgentConfig
 	agentConfig.SetDefaults()
@@ -365,4 +357,36 @@ func TestComputeManagementServerConnectionStatus_EnvoyConnected(t *testing.T) {
 
 	assert.Equal(t, "CONNECTED", healthStatus.ManagementServerConnectionStatus)
 	assert.True(t, healthStatus.ManagementServerDisconnectedTimestamp == nil)
+}
+
+func TestComputeHealthCheck_HealthStatusHealthyBelowThreshold(t *testing.T) {
+	healthStatus := HealthStatus{
+		HealthStatus:                     "",
+		EnvoyState:                       "LIVE",
+		ManagementServerConnectionStatus: "CONNECTED",
+		HealthStatusFlipCount:            4, // Below the threshold
+	}
+
+	var agentConfig config.AgentConfig
+	agentConfig.SetDefaults()
+
+	healthStatus.computeHealthCheck(agentConfig)
+
+	assert.Equal(t, "HEALTHY", healthStatus.HealthStatus)
+}
+
+func TestComputeHealthCheck_HealthStatusUnhealthyAboveThreshold(t *testing.T) {
+	healthStatus := HealthStatus{
+		HealthStatus:                     "",
+		EnvoyState:                       "LIVE",
+		ManagementServerConnectionStatus: "DISCONNECTED",
+		HealthStatusFlipCount:            5, // At the threshold
+	}
+
+	var agentConfig config.AgentConfig
+	agentConfig.SetDefaults()
+
+	healthStatus.computeHealthCheck(agentConfig)
+
+	assert.Equal(t, "UNHEALTHY", healthStatus.HealthStatus)
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
The AppNet agent currently monitors its connection to the EMS, marking itself as unhealthy if it disconnects from the control plane EMS for [3 hours](https://code.amazon.com/packages/ECNControllerResourceManagementService/blobs/74d603[%E2%80%A6]zil-config/app/ECNControllerResourceManagementService.cfg.erb). However, if the relay container exits and fails to restart, possibly due to resource constraints, the AppNet agent loses its connection to the EMS. Yet, the task will only be marked as unhealthy after a grace period of 3 hours.

This change is to change the current SC health check compute logic to health flip with a initial threshold of 5 to detect the failure impact of relay agent earlier.

SIM: https://sim.amazon.com/issues/LATTICE-BE-10167

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
Please ensure unit and integration tests pass (on at least one platform) before opening the pull request.
Once you open the pull request, there will be several automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it.
-->

New tests cover the changes: YES
Manually build at the local, and it works fine.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
