### PR TITLE
Change SC agent health compute logic to health flip

### DIFF
--- a/agent/healthcheck/health_check.go
+++ b/agent/healthcheck/health_check.go
@@ -50,18 +50,17 @@ const (
 )
 
 type HealthStatus struct {
-	HealthStatus                          string     `json:"healthStatus"`
-	AgentUptime                           string     `json:"agentUptime"`
-	EnvoyPid                              string     `json:"envoyPid"`
-	EnvoyState                            string     `json:"envoyState"`
-	EnvoyRestartCount                     string     `json:"envoyRestartCount"`
-	ManagementServerConnectionStatus      string     `json:"managementServerConnectionStatus,omitempty"`
-	ManagementServerDisconnectedTimestamp *time.Time `json:"managementServerDisconnectedTimestamp,omitempty"`
-	EnvoyReadinessState                   string     `json:"envoyReadinessState"`
-	InitialConfigUpdateStatus             string     `json:"initialConfigUpdateStatus,omitempty"`
-	HealthStatusFlipCount                 int        `json:"HealthStatusFlipCount,omitempty"`
-    LastConnectionStatus                  string     `json:"lastConnectionStatus,omitempty"` //Represents the last ManagementServerConnectionStatus
-    FlipTimestamps                     []time.Time   `json:"FlipTimestamps,omitempty"` //Denotes the times when the connection status has flipped
+	HealthStatus                          string      `json:"healthStatus"`
+	AgentUptime                           string      `json:"agentUptime"`
+	EnvoyPid                              string      `json:"envoyPid"`
+	EnvoyState                            string      `json:"envoyState"`
+	EnvoyRestartCount                     string      `json:"envoyRestartCount"`
+	ManagementServerConnectionStatus      string      `json:"managementServerConnectionStatus,omitempty"`
+	ManagementServerDisconnectedTimestamp *time.Time  `json:"managementServerDisconnectedTimestamp,omitempty"`
+	EnvoyReadinessState                   string      `json:"envoyReadinessState"`
+	InitialConfigUpdateStatus             string      `json:"initialConfigUpdateStatus,omitempty"`
+	LastConnectionStatus                  string      `json:"lastConnectionStatus,omitempty"` //Represents the last ManagementServerConnectionStatus
+	FlipTimestamps                        []time.Time `json:"FlipTimestamps,omitempty"`       //Denotes the times when the connection status has flipped
 }
 
 type HealthStatusHandler struct {
@@ -242,16 +241,11 @@ func (healthStatus *HealthStatus) computeHealthCheck(agentConfig config.AgentCon
             healthStatus.LastConnectionStatus = healthStatus.ManagementServerConnectionStatus
         }
 
-        if healthStatus.ManagementServerConnectionStatus == connected {
-            healthStatus.HealthStatus = Healthy
-            healthStatus.FlipTimestamps = nil // clear the timestamps as the connection is now stable
-        } else {
-            if len(healthStatus.FlipTimestamps) >= 10 {
-                healthStatus.HealthStatus = Unhealthy
-            } else {
-                healthStatus.HealthStatus = Healthy
-            }
-        }
+		if len(healthStatus.FlipTimestamps) >= 10 {
+			healthStatus.HealthStatus = Unhealthy
+		} else {
+			healthStatus.HealthStatus = Healthy
+		}
 
 	default:
 		healthStatus.HealthStatus = Unhealthy

--- a/agent/healthcheck/health_check.go
+++ b/agent/healthcheck/health_check.go
@@ -59,6 +59,9 @@ type HealthStatus struct {
 	ManagementServerDisconnectedTimestamp *time.Time `json:"managementServerDisconnectedTimestamp,omitempty"`
 	EnvoyReadinessState                   string     `json:"envoyReadinessState"`
 	InitialConfigUpdateStatus             string     `json:"initialConfigUpdateStatus,omitempty"`
+	HealthStatusFlipCount                 int        `json:"HealthStatusFlipCount,omitempty"`
+    LastConnectionStatus                  string     `json:"lastConnectionStatus,omitempty"` //Represents the last ManagementServerConnectionStatus
+    FlipTimestamps                     []time.Time   `json:"FlipTimestamps,omitempty"` //Denotes the times when the connection status has flipped
 }
 
 type HealthStatusHandler struct {
@@ -196,8 +199,19 @@ func (healthStatus *HealthStatus) computeHealthCheck(agentConfig config.AgentCon
 	// it is reported as Unhealthy.
 	// Disconnection from Control plane (Applicable only when not using Relay Mode):
 	// - Even when initialized, Envoy is statically stable and hence continue to report healthy.
-	// - To prevent Envoy from getting stuck in a disconnected state, we define a configurable threshold crossing which
-	//   it starts reporting unhealthy.
+    // - If the connection status is CONNECTED, Envoy is reported as Healthy, and FlipTimestamps is reset.
+    // - If the connection status is NOT CONNECTED and has changed since the last check,
+    //   the current time is appended to FlipTimestamps, provided that the timestamp is within the last 30 minutes.
+    // - If the length of FlipTimestamps reaches or exceeds a predefined threshold of 10, Envoy is reported as Unhealthy.
+    //   Otherwise, it is reported as Healthy.
+
+    currentTime := time.Now()
+
+    // If LastConnectionStatus is empty, initialize it with the value of ManagementServerConnectionStatus.
+    if healthStatus.LastConnectionStatus == "" {
+        healthStatus.LastConnectionStatus = healthStatus.ManagementServerConnectionStatus
+    }
+
 	switch healthStatus.EnvoyState {
 	case LIVE:
 		if healthStatus.InitialConfigUpdateStatus == UPDATE_FAILED {
@@ -208,15 +222,37 @@ func (healthStatus *HealthStatus) computeHealthCheck(agentConfig config.AgentCon
 			healthStatus.HealthStatus = Healthy
 			break
 		}
-		if healthStatus.ManagementServerConnectionStatus == connected {
-			healthStatus.HealthStatus = Healthy
-		} else {
-			if time.Since(*healthStatus.ManagementServerDisconnectedTimestamp) < agentConfig.HcDisconnectedTimeout {
-				healthStatus.HealthStatus = Healthy
-			} else {
-				healthStatus.HealthStatus = Unhealthy
-			}
-		}
+
+    // If ManagementServerConnectionStatus has changed since the last update, add the current time to FlipTimestamps.
+        if healthStatus.ManagementServerConnectionStatus != healthStatus.LastConnectionStatus {
+            healthStatus.FlipTimestamps = append(healthStatus.FlipTimestamps, currentTime)
+
+            // Remove timestamps older than 30 minutes from FlipTimestamps.
+            thirtyMinutesAgo := currentTime.Add(-30 * time.Minute)
+            count := 0
+            for i, timestamp := range healthStatus.FlipTimestamps {
+                if timestamp.After(thirtyMinutesAgo) {
+                    break
+                }
+                count = i + 1
+            }
+            healthStatus.FlipTimestamps = healthStatus.FlipTimestamps[count:]
+
+            // Update LastConnectionStatus with the current ManagementServerConnectionStatus.
+            healthStatus.LastConnectionStatus = healthStatus.ManagementServerConnectionStatus
+        }
+
+        if healthStatus.ManagementServerConnectionStatus == connected {
+            healthStatus.HealthStatus = Healthy
+            healthStatus.FlipTimestamps = nil // clear the timestamps as the connection is now stable
+        } else {
+            if len(healthStatus.FlipTimestamps) >= 10 {
+                healthStatus.HealthStatus = Unhealthy
+            } else {
+                healthStatus.HealthStatus = Healthy
+            }
+        }
+
 	default:
 		healthStatus.HealthStatus = Unhealthy
 	}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
The AppNet agent currently monitors its connection to the EMS, marking itself as unhealthy if it disconnects from the control plane EMS for [3 hours](https://code.amazon.com/packages/ECNControllerResourceManagementService/blobs/74d603%5B%E2%80%A6%5Dzil-config/app/ECNControllerResourceManagementService.cfg.erb). However, if the relay container exits and fails to restart, possibly due to resource constraints, the AppNet agent loses its connection to the EMS. Yet, the task will only be marked as unhealthy after a grace period of 3 hours.

This change is to change the current SC health check compute logic to health flip with a initial threshold of `10 flip within 30 minutes` to detect the failure impact of relay agent earlier.

SIM: https://sim.amazon.com/issues/LATTICE-BE-10167

### Implementation details
FlipTimeStamps measures the connection between the Envoy proxy and EMS. It keeps tracks of the times when the connection status flips. TimeStamps older than 30 minutes are removed. If the length of FlipTimeStamps reaches or exceeds the threshold (`10 flip within 30 minutes`), the health status will be marked as `Unhealthy`. Else it will remain healthy.
### Testing
<!-- How was this tested? --> 
<!--
Note for external contributors:
Please ensure unit and integration tests pass (on at least one platform) before opening the pull request.
Once you open the pull request, there will be several automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it.
-->

New tests cover the changes: yes
Manual build succeeded at local.
### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
