### PR TITLE
Add TCP keep alive for relay bootstrap

### DIFF
--- a/agent/resources/bootstrap_configs/relay_bootstrap.yaml
+++ b/agent/resources/bootstrap_configs/relay_bootstrap.yaml
@@ -65,6 +65,11 @@ static_resources:
           "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           explicit_http_config:
             http2_protocol_options: {}
+      upstream_connection_options:
+        # Send TCP keep alive in case upstream closing the connection
+        # https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#envoy-v3-api-msg-config-core-v3-tcpkeepalive
+        tcp_keepalive:
+          keepalive_time: 200 # The number of seconds a connection needs to be idle before keep-alive probes start being sent.
       lb_policy: round_robin
       per_connection_buffer_limit_bytes: $RELAY_BUFFER_LIMIT_BYTES
       load_assignment:


### PR DESCRIPTION
### Summary
This change adds TCP keep alive to relay bootstrap to keep relay's connection with its upstream in case of idle timeout for TCP connections.

### Implementation details
Following official Envoy doc: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#envoy-v3-api-msg-config-core-v3-tcpkeepalive to configure the keep alive.

### Testing
Build image locally and using it for testing.
1. Make sure the change won't impact current behavior of SC.
2. Make sure the change be able fix the current issue.

New tests cover the changes: yes

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
