### PR TITLE
Enable debug loglevel for aws component in relay

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -65,6 +65,13 @@ func buildCommandArgs(agentConfig config.AgentConfig) []string {
 	} else if agentConfig.EnableRelayModeForXds {
 		args = append(args, "--concurrency")
 		args = append(args, config.ENVOY_CONCURRENCY_FOR_RELAY_DEFAULT)
+
+		// If --log-level is not debug and not trace then set `aws` --component-log-level to debug.
+		// https://www.envoyproxy.io/docs/envoy/latest/operations/cli.html#cmdoption-component-log-level
+		if agentConfig.EnvoyLogLevel != "debug" && agentConfig.EnvoyLogLevel != "trace" {
+			args = append(args, "--component-log-level")
+			args = append(args, "aws:debug")
+		}
 	}
 
 	listenerDrainWaitTime := int(agentConfig.ListenerDrainWaitTime / time.Second)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -61,6 +61,54 @@ func TestBuildCommandArgs(t *testing.T) {
 	}, arguments)
 }
 
+func TestBuildCommandArgs_ConcurrencySet(t *testing.T) {
+	var agentConfig config.AgentConfig
+	os.Setenv("ENVOY_CONCURRENCY", "2")
+	defer os.Unsetenv("ENVOY_CONCURRENCY")
+
+	agentConfig.SetDefaults()
+
+	arguments := buildCommandArgs(agentConfig)
+
+	assert.Equal(t, len(arguments), 9)
+	assert.ElementsMatch(t, []string{
+		agentConfig.CommandPath,
+		"-c",
+		agentConfig.EnvoyConfigPath,
+		"-l",
+		agentConfig.EnvoyLogLevel,
+		"--concurrency",
+		"2",
+		"--drain-time-s",
+		strconv.Itoa(int(agentConfig.ListenerDrainWaitTime / time.Second)),
+	}, arguments)
+}
+
+func TestBuildCommandArgsForRelay(t *testing.T) {
+	var agentConfig config.AgentConfig
+	os.Setenv("APPNET_ENABLE_RELAY_MODE_FOR_XDS", "true")
+	defer os.Unsetenv("APPNET_ENABLE_RELAY_MODE_FOR_XDS")
+
+	agentConfig.SetDefaults()
+
+	arguments := buildCommandArgs(agentConfig)
+
+	assert.Equal(t, len(arguments), 11)
+	assert.ElementsMatch(t, []string{
+		agentConfig.CommandPath,
+		"-c",
+		agentConfig.EnvoyConfigPath,
+		"-l",
+		agentConfig.EnvoyLogLevel,
+		"--concurrency",
+		"1",
+		"--component-log-level",
+		"aws:debug",
+		"--drain-time-s",
+		strconv.Itoa(int(agentConfig.ListenerDrainWaitTime / time.Second)),
+	}, arguments)
+}
+
 func TestBuildCommandArgsNoEnvoyParameters(t *testing.T) {
 	var agentConfig config.AgentConfig
 


### PR DESCRIPTION
### Summary
Enable debug loglevel for [aws](https://github.com/envoyproxy/envoy/blob/1ef48e62bfff7be0403d6609eb9f57e17907bcc2//source/common/common/logger.h#L39) component in relay

Since major of function of Relay is to sign the request by fetching the IMDSv2 credentials, we can afford to have debug logs in production for only aws component.

The log is not dependent on customer's dataplane traffic and is only fetched every 1 hour to refresh the credentials. In case of issue fetching the credentials the logs will help identify the problem faster instead of teaching customer how to fetch the debug level logs from relay container.

This will help chase the issues where Relay is not able to fetch the credentials because IMDS is disabled. Or in other instances token fetch fails and Envoy end up doing IMDSv1 calls etc.



### Implementation details
Enable https://www.envoyproxy.io/docs/envoy/latest/operations/cli.html#cmdoption-component-log-level component log level only for aws component.


### Testing
New tests cover the changes: yes


Manual testing logs which will start showing up inside relay container at /var/logs/*
```
[2023-11-27 18:44:12.302][2768][debug][aws] [source/extensions/common/aws/credentials_provider_impl.cc:281] Getting AWS credentials from the EC2MetadataService
[2023-11-27 18:44:12.302][2768][debug][aws] [source/extensions/common/aws/metadata_fetcher.cc:78] fetch AWS Metadata from the cluster ec2_instance_metadata_server_internal at [uri = http://169.254.169.254/latest/api/token]
[2023-11-27 18:44:12.303][2768][debug][aws] [source/extensions/common/aws/metadata_fetcher.cc:127] onSuccess: fetch AWS Metadata [cluster = ec2_instance_metadata_server_internal]: success
[2023-11-27 18:44:12.303][2768][debug][aws] [source/extensions/common/aws/credentials_provider_impl.cc:452] AWS Instance metadata fetch success, calling callback func
[2023-11-27 18:44:12.303][2768][debug][aws] [source/extensions/common/aws/metadata_fetcher.cc:78] fetch AWS Metadata from the cluster ec2_instance_metadata_server_internal at [uri = http://169.254.169.254/latest/meta-data/iam/security-credentials]
[2023-11-27 18:44:12.304][2768][debug][aws] [source/extensions/common/aws/metadata_fetcher.cc:127] onSuccess: fetch AWS Metadata [cluster = ec2_instance_metadata_server_internal]: success
[2023-11-27 18:44:12.304][2768][debug][aws] [source/extensions/common/aws/credentials_provider_impl.cc:452] AWS Instance metadata fetch success, calling callback func
[2023-11-27 18:44:12.304][2768][debug][aws] [source/extensions/common/aws/credentials_provider_impl.cc:375] AWS credentials list:
loadtest-asg-ECSInstanceRole
[2023-11-27 18:44:12.304][2768][debug][aws] [source/extensions/common/aws/credentials_provider_impl.cc:382] AWS credentials path: /latest/meta-data/iam/security-credentials/loadtest-asg-ECSInstanceRole
[2023-11-27 18:44:12.304][2768][debug][aws] [source/extensions/common/aws/metadata_fetcher.cc:78] fetch AWS Metadata from the cluster ec2_instance_metadata_server_internal at [uri = http://169.254.169.254/latest/meta-data/iam/security-credentials/loadtest-asg-ECSInstanceRole]
[2023-11-27 18:44:12.304][2768][debug][aws] [source/extensions/common/aws/metadata_fetcher.cc:127] onSuccess: fetch AWS Metadata [cluster = ec2_instance_metadata_server_internal]: success
[2023-11-27 18:44:12.304][2768][debug][aws] [source/extensions/common/aws/credentials_provider_impl.cc:452] AWS Instance metadata fetch success, calling callback func
[2023-11-27 18:44:12.304][2768][debug][aws] [source/extensions/common/aws/credentials_provider_impl.cc:438] Obtained following AWS credentials from the EC2MetadataService: AWS_ACCESS_KEY_ID=ASIA5AKVMPN45UBMHOR2, AWS_SECRET_ACCESS_KEY=*****, AWS_SESSION_TOKEN=*****
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
