### PR TITLE
Remove envoy.reloadable_feature.successful_active_health_check_uneject_host

### DIFF
--- a/agent/envoy_bootstrap/envoy_bootstrap.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap.go
@@ -128,11 +128,6 @@ func getRuntimeConfigLayer0() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	setActiveHealthCheckUnejectHost, err := env.TruthyOrElse("ENVOY_ACTIVE_HEALTH_CHECK_UNEJECT_HOST", false)
-	if err != nil {
-		return nil, err
-	}
-
 	// ====== Runtime config with defaults set ======
 	result := map[string]interface{}{
 		// Allow all deprecated features to be enabled by Envoy. This prevents warnings or hard errors when
@@ -161,13 +156,6 @@ func getRuntimeConfigLayer0() (map[string]interface{}, error) {
 		// in request path logged in traces and access logs. So in case user wants to keep the original behavior because
 		// CVE is not applicable in their case then they can set Envoy env variable ENVOY_SANITIZE_ORIGINAL_PATH to `false`.
 		"envoy.reloadable_features.sanitize_original_path": setSanitizeOriginalPath,
-
-		// Default is set to false.
-		// Envoy made a change to outlier detection with active healthchecks enabled. If active HC is enabled and a host
-		// is ejected by outlier detection, a successful active health check unejects the host and consider it healthy.
-		// This also clears all the outlier detection counters. To enable the new behavior, set Envoy env variable
-		// ENVOY_ACTIVE_HEALTH_CHECK_UNEJECT_HOST to `true`.
-		"envoy.reloadable_features.successful_active_health_check_uneject_host": setActiveHealthCheckUnejectHost,
 	}
 
 	// ====== Runtime config with no defaults set ======

--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -674,7 +674,6 @@ metadata:
     envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
     envoy.reloadable_features.no_extension_lookup_by_name: true
     envoy.reloadable_features.sanitize_original_path: true
-    envoy.reloadable_features.successful_active_health_check_uneject_host: false
     re2.max_program_size.error_level: 1000
 `)
 }
@@ -687,8 +686,6 @@ func TestBuildNodeMetadata_StaticRuntimeMappingDefaultOverridden(t *testing.T) {
 	defer os.Unsetenv("ENVOY_NO_EXTENSION_LOOKUP_BY_NAME")
 	os.Setenv("ENVOY_SANITIZE_ORIGINAL_PATH", "false")
 	defer os.Unsetenv("ENVOY_SANITIZE_ORIGINAL_PATH")
-	os.Setenv("ENVOY_ACTIVE_HEALTH_CHECK_UNEJECT_HOST", "true")
-	defer os.Unsetenv("ENVOY_ACTIVE_HEALTH_CHECK_UNEJECT_HOST")
 	os.Setenv("MAX_REQUESTS_PER_IO_CYCLE", "1")
 	defer os.Unsetenv("MAX_REQUESTS_PER_IO_CYCLE")
 	metadata, err := buildMetadataForNode()
@@ -703,7 +700,6 @@ metadata:
     envoy.reloadable_features.http_set_tracing_decision_in_request_id: false
     envoy.reloadable_features.no_extension_lookup_by_name: false
     envoy.reloadable_features.sanitize_original_path: false
-    envoy.reloadable_features.successful_active_health_check_uneject_host: true
     re2.max_program_size.error_level: 1000
     http.max_requests_per_io_cycle: 1
 `)
@@ -723,7 +719,6 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.sanitize_original_path: true
-      envoy.reloadable_features.successful_active_health_check_uneject_host: false
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}
@@ -746,7 +741,6 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: false
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.sanitize_original_path: true
-      envoy.reloadable_features.successful_active_health_check_uneject_host: false
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}
@@ -769,7 +763,6 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: false
       envoy.reloadable_features.sanitize_original_path: true
-      envoy.reloadable_features.successful_active_health_check_uneject_host: false
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}
@@ -792,30 +785,6 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.sanitize_original_path: false
-      envoy.reloadable_features.successful_active_health_check_uneject_host: false
-      re2.max_program_size.error_level: 1000
-  - name: "admin_layer"
-    adminLayer: {}
-`)
-}
-
-func TestBuildLayeredRuntime_ActiveHealthcheckUnejectHost(t *testing.T) {
-	setup()
-	os.Setenv("ENVOY_ACTIVE_HEALTH_CHECK_UNEJECT_HOST", "true")
-	defer os.Unsetenv("ENVOY_ACTIVE_HEALTH_CHECK_UNEJECT_HOST")
-	rt, err := buildLayeredRuntime()
-	if err != nil {
-		t.Error(err)
-	}
-	checkMessage(t, rt, `
-layers:
-  - name: "static_layer_0"
-    staticLayer:
-      envoy.features.enable_all_deprecated_features: true
-      envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
-      envoy.reloadable_features.no_extension_lookup_by_name: true
-      envoy.reloadable_features.sanitize_original_path: true
-      envoy.reloadable_features.successful_active_health_check_uneject_host: true
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}
@@ -838,7 +807,6 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.sanitize_original_path: true
-      envoy.reloadable_features.successful_active_health_check_uneject_host: false
       re2.max_program_size.error_level: 1000
       http.max_requests_per_io_cycle: 1
   - name: "admin_layer"
@@ -862,7 +830,6 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.sanitize_original_path: true
-      envoy.reloadable_features.successful_active_health_check_uneject_host: false
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}


### PR DESCRIPTION
To be included with v1.28+ releases only and not before.

### Summary
From v1.28 Envoy release this feature flag has been removed in https://github.com/envoyproxy/envoy/pull/29303. See Envoy [v1.28.0](https://www.envoyproxy.io/docs/envoy/v1.28.0/version_history/v1.28/v1.28.0) release notes.

> healthcheck: Removed envoy.reloadable_features_successful_active_health_check_uneject_host runtime option and substituted it with [outlier_detection.successful_active_health_check_uneject_host](https://www.envoyproxy.io/docs/envoy/v1.28.0/api-v3/config/cluster/v3/outlier_detection.proto#envoy-v3-api-field-config-cluster-v3-outlierdetection-successful-active-health-check-uneject-host) outlier detection configuration flag.

### Implementation details
Revert of earlier change https://github.com/aws/amazon-ecs-service-connect-agent/pull/38

### Testing
New tests cover the changes: yes

### Description for the changelog
Removed option to set envoy.reloadable_feature.successful_active_health_check_uneject_host

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
