### PR TITLE
Ability to set use_http_client_to_fetch_aws_credentials

### DIFF
--- a/agent/config/agent_config.go
+++ b/agent/config/agent_config.go
@@ -49,6 +49,8 @@ const (
 
 	ENABLE_STATS_SNAPSHOT_DEFAULT = false
 
+	ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS_DEFAULT = false
+
 	ENVOY_SERVER_SCHEME                  = "http"
 	ENVOY_SERVER_HOSTNAME                = "127.0.0.1"
 	ENVOY_RESTART_COUNT_DEFAULT          = 0
@@ -169,6 +171,9 @@ type AgentConfig struct {
 	AppNetRelayListenerUdsPath string
 	RelayStreamIdleTimeout     string
 	RelayBufferLimitBytes      int
+
+	// Libcurl deprecation Envoy reloadable feature flag
+	EnvoyUseHttpClientToFetchAwsCredentials bool
 
 	// Poll intervals
 	PidPollInterval       time.Duration
@@ -448,6 +453,9 @@ func (config *AgentConfig) SetDefaults() {
 			config.AppNetManagementDomainName = xdsDomain
 		}
 	}
+
+	// Libcurl deprecation Envoy reloadable feature flag
+	config.EnvoyUseHttpClientToFetchAwsCredentials = getEnvValueAsBool("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS", ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS_DEFAULT)
 
 	config.AgentAdminMode = getAdminModeFromEnv("APPNET_AGENT_ADMIN_MODE", AGENT_ADMIN_MODE_DEFAULT)
 	if config.AgentAdminMode == UDS {

--- a/agent/config/agent_config_test.go
+++ b/agent/config/agent_config_test.go
@@ -44,6 +44,7 @@ func TestPopulateDefaultAgentConfig(t *testing.T) {
 	assert.NotEmpty(t, agentConfig.EnvoyConfigPath)
 	assert.True(t, strings.HasSuffix(agentConfig.EnvoyConfigPath, ".yaml"))
 	assert.Empty(t, agentConfig.ClusterIPMapping)
+	assert.False(t, agentConfig.EnvoyUseHttpClientToFetchAwsCredentials)
 }
 
 func TestPopulateAgentConfigWithEnvVars(t *testing.T) {
@@ -95,6 +96,17 @@ func TestEnvoyAdminModeUds(t *testing.T) {
 	assert.Equal(t, UDS, agentConfig.EnvoyAdminMode)
 }
 
+func TestEnvoyOverrideUseHttpClient(t *testing.T) {
+	os.Setenv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS", "true")
+	defer os.Unsetenv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS")
+	var agentConfig AgentConfig
+
+	agentConfig.SetDefaults()
+
+	assert.NotNil(t, agentConfig)
+	assert.True(t, agentConfig.EnvoyUseHttpClientToFetchAwsCredentials)
+}
+
 func TestEnableRelayModeForXds(t *testing.T) {
 	os.Setenv("APPNET_ENABLE_RELAY_MODE_FOR_XDS", "1")
 	os.Setenv("APPNET_AGENT_ADMIN_MODE", "UDS")
@@ -112,6 +124,7 @@ func TestEnableRelayModeForXds(t *testing.T) {
 	assert.Equal(t, 443, agentConfig.AppNetManagementPort)
 	assert.Equal(t, "2400s", agentConfig.RelayStreamIdleTimeout)
 	assert.Equal(t, 10485760, agentConfig.RelayBufferLimitBytes)
+	assert.False(t, agentConfig.EnvoyUseHttpClientToFetchAwsCredentials)
 }
 
 func TestEnableRelayModeForXds_domainWithScheme(t *testing.T) {

--- a/agent/envoy_bootstrap/envoy_bootstrap.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap.go
@@ -128,6 +128,11 @@ func getRuntimeConfigLayer0() (map[string]interface{}, error) {
 		return nil, err
 	}
 
+	setUseHttpClientToFetchAwsCredentials, err := env.TruthyOrElse("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS", false)
+	if err != nil {
+		return nil, err
+	}
+
 	// ====== Runtime config with defaults set ======
 	result := map[string]interface{}{
 		// Allow all deprecated features to be enabled by Envoy. This prevents warnings or hard errors when
@@ -156,6 +161,16 @@ func getRuntimeConfigLayer0() (map[string]interface{}, error) {
 		// in request path logged in traces and access logs. So in case user wants to keep the original behavior because
 		// CVE is not applicable in their case then they can set Envoy env variable ENVOY_SANITIZE_ORIGINAL_PATH to `false`.
 		"envoy.reloadable_features.sanitize_original_path": setSanitizeOriginalPath,
+
+		// Default is set to false.
+		// Envoy introduced an option to use http async client to fetch aws metadata credentials instead of using libcurl.
+		// This effort was to deprecated the usage of libcurl in Envoy.
+		// See:
+		// https://github.com/envoyproxy/envoy/pull/29880
+		// https://github.com/envoyproxy/envoy/pull/30626
+		// https://github.com/envoyproxy/envoy/pull/30731
+		// https://github.com/envoyproxy/envoy/pull/31135
+		"envoy.reloadable_features.use_http_client_to_fetch_aws_credentials": setUseHttpClientToFetchAwsCredentials,
 	}
 
 	// ====== Runtime config with no defaults set ======

--- a/agent/envoy_bootstrap/envoy_bootstrap.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap.go
@@ -128,7 +128,7 @@ func getRuntimeConfigLayer0() (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	setUseHttpClientToFetchAwsCredentials, err := env.TruthyOrElse("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS", false)
+	setUseHttpClientToFetchAwsCredentials, err := env.TruthyOrElse("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS", config.ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS_DEFAULT)
 	if err != nil {
 		return nil, err
 	}
@@ -1662,6 +1662,12 @@ func setRelayBootstrapEnvVariables(agentConfig config.AgentConfig, envoyCLIInst 
 		log.Infof("RELAY_BUFFER_LIMIT_BYTES is not set, setting default value as: %v", agentConfig.RelayBufferLimitBytes)
 		os.Setenv("RELAY_BUFFER_LIMIT_BYTES", fmt.Sprint(agentConfig.RelayBufferLimitBytes))
 	}
+
+	if _, exists := os.LookupEnv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS"); !exists {
+		log.Infof("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS is not set, setting default value as: %v", agentConfig.EnvoyUseHttpClientToFetchAwsCredentials)
+		os.Setenv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS", fmt.Sprint(agentConfig.EnvoyUseHttpClientToFetchAwsCredentials))
+	}
+
 	return nil
 }
 

--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -674,6 +674,7 @@ metadata:
     envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
     envoy.reloadable_features.no_extension_lookup_by_name: true
     envoy.reloadable_features.sanitize_original_path: true
+    envoy.reloadable_features.use_http_client_to_fetch_aws_credentials: false
     re2.max_program_size.error_level: 1000
 `)
 }
@@ -688,6 +689,8 @@ func TestBuildNodeMetadata_StaticRuntimeMappingDefaultOverridden(t *testing.T) {
 	defer os.Unsetenv("ENVOY_SANITIZE_ORIGINAL_PATH")
 	os.Setenv("MAX_REQUESTS_PER_IO_CYCLE", "1")
 	defer os.Unsetenv("MAX_REQUESTS_PER_IO_CYCLE")
+	os.Setenv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS", "true")
+	defer os.Unsetenv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS")
 	metadata, err := buildMetadataForNode()
 	assert.Nil(t, err)
 	// ignore metadata: aws.appmesh.platformInfo & aws.appmesh.task.interfaces
@@ -700,6 +703,7 @@ metadata:
     envoy.reloadable_features.http_set_tracing_decision_in_request_id: false
     envoy.reloadable_features.no_extension_lookup_by_name: false
     envoy.reloadable_features.sanitize_original_path: false
+    envoy.reloadable_features.use_http_client_to_fetch_aws_credentials: true
     re2.max_program_size.error_level: 1000
     http.max_requests_per_io_cycle: 1
 `)
@@ -719,6 +723,7 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.sanitize_original_path: true
+      envoy.reloadable_features.use_http_client_to_fetch_aws_credentials: false
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}
@@ -741,6 +746,7 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: false
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.sanitize_original_path: true
+      envoy.reloadable_features.use_http_client_to_fetch_aws_credentials: false
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}
@@ -763,6 +769,7 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: false
       envoy.reloadable_features.sanitize_original_path: true
+      envoy.reloadable_features.use_http_client_to_fetch_aws_credentials: false
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}
@@ -785,6 +792,7 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.sanitize_original_path: false
+      envoy.reloadable_features.use_http_client_to_fetch_aws_credentials: false
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}
@@ -807,6 +815,7 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.sanitize_original_path: true
+      envoy.reloadable_features.use_http_client_to_fetch_aws_credentials: false
       re2.max_program_size.error_level: 1000
       http.max_requests_per_io_cycle: 1
   - name: "admin_layer"
@@ -830,6 +839,30 @@ layers:
       envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
       envoy.reloadable_features.no_extension_lookup_by_name: true
       envoy.reloadable_features.sanitize_original_path: true
+      envoy.reloadable_features.use_http_client_to_fetch_aws_credentials: false
+      re2.max_program_size.error_level: 1000
+  - name: "admin_layer"
+    adminLayer: {}
+`)
+}
+
+func TestBuildLayeredRuntime_UseHttpClientToFetchAwsCredentials(t *testing.T) {
+	setup()
+	os.Setenv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS", "true")
+	defer os.Unsetenv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS")
+	rt, err := buildLayeredRuntime()
+	if err != nil {
+		t.Error(err)
+	}
+	checkMessage(t, rt, `
+layers:
+  - name: "static_layer_0"
+    staticLayer:
+      envoy.features.enable_all_deprecated_features: true
+      envoy.reloadable_features.http_set_tracing_decision_in_request_id: true
+      envoy.reloadable_features.no_extension_lookup_by_name: true
+      envoy.reloadable_features.sanitize_original_path: true
+      envoy.reloadable_features.use_http_client_to_fetch_aws_credentials: true
       re2.max_program_size.error_level: 1000
   - name: "admin_layer"
     adminLayer: {}

--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -2975,6 +2975,9 @@ func TestRelayBootstrap_DefaultValuesSetForEnvVariables(t *testing.T) {
 
 	_, f_exists := os.LookupEnv("RELAY_BUFFER_LIMIT_BYTES")
 	assert.True(t, f_exists)
+
+	_, g_exists := os.LookupEnv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS")
+	assert.True(t, g_exists)
 }
 
 func TestRelayBootstrap_DefaultValuesSetForEnvVariableFips(t *testing.T) {
@@ -3010,6 +3013,9 @@ func TestRelayBootstrap_DefaultValuesSetForEnvVariableFips(t *testing.T) {
 
 	_, f_exists := os.LookupEnv("RELAY_BUFFER_LIMIT_BYTES")
 	assert.True(t, f_exists)
+
+	_, g_exists := os.LookupEnv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS")
+	assert.True(t, g_exists)
 }
 
 func TestRelayBootstrap_DefaultValuesSetForEnvVariablesInGovCloud(t *testing.T) {
@@ -3045,6 +3051,9 @@ func TestRelayBootstrap_DefaultValuesSetForEnvVariablesInGovCloud(t *testing.T) 
 
 	_, f_exists := os.LookupEnv("RELAY_BUFFER_LIMIT_BYTES")
 	assert.True(t, f_exists)
+
+	_, g_exists := os.LookupEnv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS")
+	assert.True(t, g_exists)
 }
 
 func TestRelayBootstrap_NotFipsCompatibleInGovCloud(t *testing.T) {

--- a/agent/resources/bootstrap_configs/relay_bootstrap.yaml
+++ b/agent/resources/bootstrap_configs/relay_bootstrap.yaml
@@ -90,6 +90,7 @@ layered_runtime:
   layers:
     - name: "static_layer_0"
       staticLayer:
+        envoy.reloadable_features.use_http_client_to_fetch_aws_credentials: $ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS
         re2.max_program_size.error_level: 1000
     - name: "admin_layer"
       adminLayer: {}


### PR DESCRIPTION
Include this change only on v1.29.x, v1.30.x Envoy release. Or on v1.28.x if upstream commits on Envoy release v1.29 are ported back.

From v1.31.x onwards this feature flag is going to be removed.

### Summary
Ability to set `envoy.reloadable_features.use_http_client_to_fetch_aws_credentials`, which defaults to `false`.

Following the changes in Envoy to deprecated libcurl, we introduced a reloadable feature flag to control whether to enable or disable the new technique of fetching the aws credentials via http async client.

For now this is default disabled and will be enabled by default in a follow up PR in the repo with a workaround to make usage of http async client work for AppMesh users.

See https://github.com/envoyproxy/envoy/pull/30731, https://github.com/envoyproxy/envoy/pull/31135, https://docs.google.com/document/d/1m1KE_LGDnxrXwnUC1OEKYLmw8szy4r06OX_O3JcM-wM

### Testing
New tests cover the changes: yes

### Description for the changelog
Option to set `envoy.reloadable_features.use_http_client_to_fetch_aws_credentials` via env variable.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
