### PR TITLE
Restart Envoy process even when terminated via signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ These environment variables offer controls to alter Amazon ECS Service Connect A
 
 |Environment Key	|Example Value(s)	|Description	|Default Value	|
 |---	|---	|---	|---	|
-|`APPNET_ENVOY_RESTART_COUNT`	|10	|The number of times the Agent will restart Envoy within a running task	|0	|
+|`APPNET_ENVOY_RESTART_COUNT`	|10	|The number of times the Agent will restart Envoy within a running task	|3	|
 |`PID_POLL_INTERVAL_MS`	|25	|The interval at which the Envoy process’ state is checked	|100	|
 |`LISTENER_DRAIN_WAIT_TIME_S`	|1	|Controls the time Envoy waits for active connections to gracefully close before the process exits	|20	|
 |`APPNET_AGENT_ADMIN_MODE`  | <tcp &#124; uds> | Starts Agent's management interface server and binds it to either a tcp address or a unix socket. |  |

--- a/agent/config/agent_config.go
+++ b/agent/config/agent_config.go
@@ -53,7 +53,7 @@ const (
 
 	ENVOY_SERVER_SCHEME                  = "http"
 	ENVOY_SERVER_HOSTNAME                = "127.0.0.1"
-	ENVOY_RESTART_COUNT_DEFAULT          = 0
+	ENVOY_RESTART_COUNT_DEFAULT          = 3
 	ENVOY_RESTART_COUNT_MAX              = 10
 	ENVOY_ADMIN_PORT_DEFAULT             = 9901
 	ENVOY_ADMIN_MODE_DEFAULT             = "tcp"


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Bug: https://github.com/aws/amazon-ecs-service-connect-agent/issues/104

Allows SC agent to restart the Envoy process when it exits abnormally via an external signal. As reported in above bug, if the envoy process within the instance Relay container is stopped via signal, the container exits and is not restarted again rendering the instance un-usable to place any Service Connect tasks.

This change allows Service Connect agent to honor the `APPNET_ENVOY_RESTART_COUNT` and automatically restart Envoy when it exits due to an external signal. Note, that a follow up change is required in the ECS agent to set a value for this variable for the relay container [here](https://github.com/aws/amazon-ecs-agent/blob/fb1fb409db15347e43334834bf5ccb85034db85f/agent/engine/serviceconnect/manager_linux.go#L65-L74).

### Implementation details
<!-- How are the changes implemented? -->
- Added additional logging to print `wstatus.Signal()` when `wstatus.Signaled()` is `true`.
- Removed logic to early exit (without restart) in `keepCommandAlive` when `waitStatus.Signaled()` is `true`.

### Testing
<!-- How was this tested? -->
Built a new ServiceConnect Envoy image and replaced it on the instance location referenced by ECS agent. Tested following scenarios.

#### Envoy process stopped manually on instance (Restart count not set or default: 0)
```
[2025-01-14 21:15:37.292][8][warning] [AppNet Agent] [Envoy process 17] Exited with code [-1]
[2025-01-14 21:15:37.292][8][warning] [AppNet Agent] [Envoy process 17] was terminated by signal: killed with Core Dump: false
```
#### Envoy process stopped manually on instance (Restart count set > 0)
```
[2025-01-14 20:02:17.653][7][warning] [AppNet Agent] [Envoy process 24] Exited with code [-1]
[2025-01-14 20:02:17.653][7][warning] [AppNet Agent] [Envoy process 24] was terminated by signal: killed with Core Dump: false
[2025-01-14 20:02:17.653][7][info] [AppNet Agent] Executing command: [/usr/bin/envoy -c /tmp/envoy-config-2145977831.yaml -l info --concurrency 2 --drain-time-s 20 --disable-hot-restart]
...
```

#### Container gracefully stopped
```
[2025-01-14 21:58:03.711][7][info] [AppNet Agent] Received request to drain listener connections.
[2025-01-14 21:58:03.860][7][info] [AppNet Agent] Draining Envoy listeners...
[2025-01-14 21:58:03.861][7][info] [AppNet Agent] Waiting 20s for Envoy to drain listeners.
[2025-01-14 21:58:23.862][7][info] [AppNet Agent] Graceful Envoy listener draining completed! Exiting...
```



### Description for the changelog
Allow Envoy process restart when terminated via external signal.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
