### PR TITLE
Enabling use of SNI by agent relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Example `Dockerfile.agent`:
 ```
 COPY agent /usr/bin/agent
 
+COPY relay_bootstrap.yaml /agent-resources/bootstrap_configs/relay_bootstrap.yaml
+
 CMD /usr/bin/agent
 ```
 
@@ -45,13 +47,15 @@ docker-build:
         ECR=$(shell echo $(IMAGE_STRING) | sed 's/\(.*\):\(.*\)/\1/g')
         echo "FROM $(IMAGE_STRING)" > source
         cat source Dockerfile.agent > Dockerfile
+        cp ../resources/bootstrap_configs/relay_bootstrap.yaml .
+	cp ../agent .
 
         aws ecr get-login-password | docker login --password-stdin --username AWS $(ECR)
         docker build -t $(IMAGE_NAME) .
         rm source Dockerfile
 ```
 
-Place these files along with the built `agent` binary in a single directory and issue the `make docker-build` command. The resulting `ecs-service-connect:latest` can be used in ECS Service Connect or App Mesh as a sidecar.
+Place these two files in a single directory within the agent directory and issue the `make docker-build` command. The resulting `ecs-service-connect:latest` can be used in ECS Service Connect or App Mesh as a sidecar.
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker-build:
         rm source Dockerfile
 ```
 
-Place these two files in a single directory within the agent directory and issue the `make docker-build` command. The resulting `ecs-service-connect:latest` can be used in ECS Service Connect or App Mesh as a sidecar.
+Use these two example files above, the Dockerfile.agent and Makefile, and place them in a single directory within the agent directory and issue the `make docker-build` command. The resulting `ecs-service-connect:latest` can be used in ECS Service Connect or App Mesh as a sidecar.
 
 ## Advanced Usage
 

--- a/agent/resources/bootstrap_configs/relay_bootstrap.yaml
+++ b/agent/resources/bootstrap_configs/relay_bootstrap.yaml
@@ -76,6 +76,7 @@ static_resources:
         name: transport_sockets.tls
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: $APPNET_MANAGEMENT_DOMAIN_NAME # DNS Name of the service you are connecting to
           common_tls_context:
             validation_context:
               trusted_ca:

--- a/agent/resources/bootstrap_configs/relay_bootstrap.yaml
+++ b/agent/resources/bootstrap_configs/relay_bootstrap.yaml
@@ -52,9 +52,6 @@ static_resources:
                       - match: { prefix: "/" }
                         route:
                           cluster: appnet_management_cluster
-      filter_chain_match:
-        server_names:
-          - $APPNET_MANAGEMENT_DOMAIN_NAME
   clusters:
     - name: appnet_management_cluster
       type: logical_dns
@@ -74,17 +71,16 @@ static_resources:
         cluster_name: appnet_management_cluster
         endpoints:
           - lb_endpoints:
-              endpoint: { address: { socket_address: { address: $APPNET_MANAGEMENT_DOMAIN_NAME, port_value: $APPNET_MANAGEMENT_PORT }}}
+              endpoint: { address: { socket_address: { address: $APPNET_MANAGEMENT_DOMAIN_NAME, port_value: $APPNET_MANAGEMENT_PORT}}}
       transport_socket:
         name: transport_sockets.tls
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          auto_host_sni: true # replaces SNI with the hostname of the upstream host if this can be found
-          sni: $APPNET_MANAGEMENT_DOMAIN_NAME # Default value for SNI - domain name of the service you are connecting to
           common_tls_context:
             validation_context:
               trusted_ca:
                 filename: /etc/pki/tls/cert.pem
+          sni: $APPNET_MANAGEMENT_DOMAIN_NAME
 
 admin:
   address:

--- a/agent/resources/bootstrap_configs/relay_bootstrap.yaml
+++ b/agent/resources/bootstrap_configs/relay_bootstrap.yaml
@@ -71,7 +71,7 @@ static_resources:
         cluster_name: appnet_management_cluster
         endpoints:
           - lb_endpoints:
-              endpoint: { address: { socket_address: { address: $APPNET_MANAGEMENT_DOMAIN_NAME, port_value: $APPNET_MANAGEMENT_PORT}}}
+              endpoint: { address: { socket_address: { address: $APPNET_MANAGEMENT_DOMAIN_NAME, port_value: $APPNET_MANAGEMENT_PORT }}}
       transport_socket:
         name: transport_sockets.tls
         typed_config:

--- a/agent/resources/bootstrap_configs/relay_bootstrap.yaml
+++ b/agent/resources/bootstrap_configs/relay_bootstrap.yaml
@@ -52,6 +52,9 @@ static_resources:
                       - match: { prefix: "/" }
                         route:
                           cluster: appnet_management_cluster
+      filter_chain_match:
+        server_names:
+          - $APPNET_MANAGEMENT_DOMAIN_NAME
   clusters:
     - name: appnet_management_cluster
       type: logical_dns
@@ -76,7 +79,8 @@ static_resources:
         name: transport_sockets.tls
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-          sni: $APPNET_MANAGEMENT_DOMAIN_NAME # DNS Name of the service you are connecting to
+          auto_host_sni: true # replaces SNI with the hostname of the upstream host if this can be found
+          sni: $APPNET_MANAGEMENT_DOMAIN_NAME # Default value for SNI - domain name of the service you are connecting to
           common_tls_context:
             validation_context:
               trusted_ca:


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
This pull will update the relay_bootstrap.yaml to enable the use of SNI by the agent relay and will also update the README to include instructions for propagating the changes to the relay_bootstrap.yaml in the newly built agent images.

### Implementation details
One line was added to relay_bootstrap.yaml to enable and set SNI to $APPNET_MANAGEMENT_DOMAIN_NAME.
Within the README, I updated the example Dockerfile.agent to include copying over the relay_bootstrap.yaml to the new image since it needs to be updated in the same manner as the agent binary. I also updated the example Makefile to copy over the agent binary and relay_bootstrap.yaml automatically, so that it isn't necessary to manually copy them over any time any changes are made and a new image is to be built.

### Testing
This was tested by building an agent image and using it to replace an agent instance on an EC2 within an ECS cluster. Then a service was run to verify that the agent was working successfully. Finally, Wireshark was used to watch the network traffic on the EC2, specifically tls handshakes, to confirm that SNI was being used to communicate with EMS. Tested with Private Link enabled and SNI properly updates to the correct endpoint.

Something that should be noted: While testing I found that on AL2 EC2 instances, SNI does not work as expected, at all. SNI only seems to work on AL2023. This is the case even when using curl to make a tls handshake with SNI.

New tests cover the changes: no

### Description for the changelog
Enabling of SNI within agent relay and modified the README to include instructions for updating the relay bootstrap.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
