### PR TITLE
Update initial backoff time to 10 second

### DIFF
--- a/agent/envoy_bootstrap/envoy_bootstrap.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap.go
@@ -77,6 +77,7 @@ const (
 	GRPC_MAX_PINGS_WITHOUT_DATA = 0
 	GRPC_KEEPALIVE_TIME_MS      = 10000
 	GRPC_KEEPALIVE_TIMEOUT_MS   = 20000
+	GRPC_INITIAL_BACKOFF_MS     = 10000
 	listenerProtocolRegex       = ".*?\\.ingress\\.((\\w+?)\\.)[0-9]+?\\.(.+?)$"
 	listenerPortRegex           = ".*?\\.ingress\\.\\w+?\\.(([0-9]+?)\\.)(.+?)$"
 	envoyRdsRouteConf           = ".*?\\.ingress\\.\\w+?\\.[0-9]+?\\.rds\\.((.*?)\\.)(.+?)$"
@@ -567,6 +568,7 @@ func buildAdsGrpcServiceForRelayEndpoint(endpoint string) (*core.GrpcService, er
 			"grpc.http2.max_pings_without_data": buildGoogleGrpcIntChannelArg(GRPC_MAX_PINGS_WITHOUT_DATA),
 			"grpc.keepalive_time_ms":            buildGoogleGrpcIntChannelArg(GRPC_KEEPALIVE_TIME_MS),
 			"grpc.keepalive_timeout_ms":         buildGoogleGrpcIntChannelArg(GRPC_KEEPALIVE_TIMEOUT_MS),
+			"grpc.initial_reconnect_backoff_ms": buildGoogleGrpcIntChannelArg(GRPC_INITIAL_BACKOFF_MS),
 		},
 	}
 	return &core.GrpcService{
@@ -586,6 +588,7 @@ func buildRegionalAdsGrpcService(endpoint string, region string, signingName str
 			"grpc.http2.max_pings_without_data": buildGoogleGrpcIntChannelArg(GRPC_MAX_PINGS_WITHOUT_DATA),
 			"grpc.keepalive_time_ms":            buildGoogleGrpcIntChannelArg(GRPC_KEEPALIVE_TIME_MS),
 			"grpc.keepalive_timeout_ms":         buildGoogleGrpcIntChannelArg(GRPC_KEEPALIVE_TIMEOUT_MS),
+			"grpc.initial_reconnect_backoff_ms": buildGoogleGrpcIntChannelArg(GRPC_INITIAL_BACKOFF_MS),
 		},
 	}
 	iamConfig, err := anypb.New(&grpc_cred.AwsIamConfig{

--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -891,6 +891,7 @@ adsConfig:
           grpc.http2.max_pings_without_data: { intValue: "0" }
           grpc.keepalive_time_ms: { intValue: "10000" }
           grpc.keepalive_timeout_ms: { intValue: "20000" }
+          grpc.initial_reconnect_backoff_ms: { intValue: "10000" }
 
 cdsConfig:
   ads: {}
@@ -923,6 +924,7 @@ adsConfig:
           grpc.http2.max_pings_without_data: { intValue: "0" }
           grpc.keepalive_time_ms: { intValue: "10000" }
           grpc.keepalive_timeout_ms: { intValue: "20000" }
+          grpc.initial_reconnect_backoff_ms: { intValue: "10000" }
 
 cdsConfig:
   ads: {}
@@ -971,6 +973,7 @@ adsConfig:
           grpc.http2.max_pings_without_data: { intValue: "0" }
           grpc.keepalive_time_ms: { intValue: "10000" }
           grpc.keepalive_timeout_ms: { intValue: "20000" }
+          grpc.initial_reconnect_backoff_ms: { intValue: "10000" }
 
 cdsConfig:
   ads: {}
@@ -1016,6 +1019,7 @@ adsConfig:
           grpc.http2.max_pings_without_data: { intValue: "0" }
           grpc.keepalive_time_ms: { intValue: "10000" }
           grpc.keepalive_timeout_ms: { intValue: "20000" }
+          grpc.initial_reconnect_backoff_ms: { intValue: "10000" }
 
 cdsConfig:
   ads: {}


### PR DESCRIPTION
### Summary
Try connection
If encounter issue in step 1, then wait for "backoff time" then retry
Increase the current backoff time, and next retry will use this new one. This backoff time is at most "max backoff"
However, we receive an issue while the exception is coming during process EMS, we will keep using initial backoff time (1 second), which cause a retry-storm that break PCA process.

For this reason, initial backoff time is increase to 10 second rather than use default 1 second.

### Implementation details
Two grpc variables are used:
"grpc.initial_reconnect_backoff_ms": initial backoff time, set to 10 sec
Notice by default, multiplier is 1.6

### Testing
In the unit test, we can test whether those backoff property are set
#### Actual test for ems failure (use new initial backoff time):
[2025-07-18 22:02:24.062][20][debug][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:125] gRPC update for type.googleapis.com/envoy.config.cluster.v3.Cluster failed
[2025-07-18 22:02:37.823][20][debug][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:125] gRPC update for type.googleapis.com/envoy.config.cluster.v3.Cluster failed"

[2025-07-18 22:02:26.480][18][debug][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:125] gRPC update for type.googleapis.com/envoy.config.cluster.v3.Cluster failed
[2025-07-18 22:02:39.816][18][debug][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:125] gRPC update for type.googleapis.com/envoy.config.cluster.v3.Cluster failed

22:02:39.814 [Thread 20] → 22:02:39.816 [Thread 18] = 0.002s (different threads)
22:02:26.480 [Thread 18] → 22:02:39.816 [Thread 18] = 13.34s (same thread ≈ 10s + jitter)
22:02:24.062 [Thread 20] → 22:02:37.823 [Thread 20] = 13.76s (same thread ≈ 10s + jitter)

#### Actual test for multiplier (default:1.6)
<img width="856" height="272" alt="image" src="https://github.com/user-attachments/assets/756dca1a-47e9-4d99-a32c-620f2dc0a8d3" />

(Notice there're two threads)

1st → 2nd: 19:23:54.430 → 19:24:04.418 = ~10.0 seconds ✓

2nd → 3rd: 19:24:04.418 → 19:24:22.133 = ~17.7 seconds ✓ (1.6x multiplier: 16 + jitter)

3rd → 4th: 19:24:22.133 → 19:24:51.713 = ~29.6 seconds ✓ (1.6x multiplier: 25.6 + jitter)

4th → 5th: 19:24:51.713 → 19:25:32.506 = ~40.8 seconds ✓ (1.6x multiplier: 40.96 + jitter (negative))

New tests cover the changes: yes

### Description for the changelog
Update initial reconnect backoff to 10 second.


### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
