### PR TITLE
Enable keep alive settings on Relay and set max connection age for control plane connection

### DIFF
--- a/agent/envoy_bootstrap/envoy_bootstrap.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap.go
@@ -69,18 +69,20 @@ var (
 )
 
 const (
-	runtimeMetadataNamespace    = "aws.appmesh.static_runtime"
-	staticResourcesKey          = "staticResources"
-	tracingKey                  = "tracing"
-	statsConfigKey              = "statsConfig"
-	statsSinksKey               = "statsSinks"
-	GRPC_MAX_PINGS_WITHOUT_DATA = 0
-	GRPC_KEEPALIVE_TIME_MS      = 10000
-	GRPC_KEEPALIVE_TIMEOUT_MS   = 20000
-	GRPC_INITIAL_BACKOFF_MS     = 10000
-	listenerProtocolRegex       = ".*?\\.ingress\\.((\\w+?)\\.)[0-9]+?\\.(.+?)$"
-	listenerPortRegex           = ".*?\\.ingress\\.\\w+?\\.(([0-9]+?)\\.)(.+?)$"
-	envoyRdsRouteConf           = ".*?\\.ingress\\.\\w+?\\.[0-9]+?\\.rds\\.((.*?)\\.)(.+?)$"
+	runtimeMetadataNamespace         = "aws.appmesh.static_runtime"
+	staticResourcesKey               = "staticResources"
+	tracingKey                       = "tracing"
+	statsConfigKey                   = "statsConfig"
+	statsSinksKey                    = "statsSinks"
+	GRPC_MAX_PINGS_WITHOUT_DATA      = 0
+	GRPC_KEEPALIVE_TIME_MS           = 10000
+	GRPC_KEEPALIVE_TIMEOUT_MS        = 20000
+	GRPC_INITIAL_BACKOFF_MS          = 10000
+	GRPC_MAX_CONNECTION_AGE_MS       = 2400000 // Set to 40 mins to be roughly equal to the interval at which connection between EMS and relay is reset
+	GRPC_MAX_CONNECTION_AGE_GRACE_MS = 5000
+	listenerProtocolRegex            = ".*?\\.ingress\\.((\\w+?)\\.)[0-9]+?\\.(.+?)$"
+	listenerPortRegex                = ".*?\\.ingress\\.\\w+?\\.(([0-9]+?)\\.)(.+?)$"
+	envoyRdsRouteConf                = ".*?\\.ingress\\.\\w+?\\.[0-9]+?\\.rds\\.((.*?)\\.)(.+?)$"
 )
 
 type EnvoyCLI interface {
@@ -575,6 +577,8 @@ func buildAdsGrpcServiceForRelayEndpoint(endpoint string) (*core.GrpcService, er
 			"grpc.keepalive_time_ms":            buildGoogleGrpcIntChannelArg(GRPC_KEEPALIVE_TIME_MS),
 			"grpc.keepalive_timeout_ms":         buildGoogleGrpcIntChannelArg(GRPC_KEEPALIVE_TIMEOUT_MS),
 			"grpc.initial_reconnect_backoff_ms": buildGoogleGrpcIntChannelArg(GRPC_INITIAL_BACKOFF_MS),
+			"grpc.max_connection_age_ms":        buildGoogleGrpcIntChannelArg(GRPC_MAX_CONNECTION_AGE_MS),
+			"grpc.max_connection_age_grace_ms":  buildGoogleGrpcIntChannelArg(GRPC_MAX_CONNECTION_AGE_GRACE_MS),
 		},
 	}
 	return &core.GrpcService{
@@ -595,6 +599,8 @@ func buildRegionalAdsGrpcService(endpoint string, region string, signingName str
 			"grpc.keepalive_time_ms":            buildGoogleGrpcIntChannelArg(GRPC_KEEPALIVE_TIME_MS),
 			"grpc.keepalive_timeout_ms":         buildGoogleGrpcIntChannelArg(GRPC_KEEPALIVE_TIMEOUT_MS),
 			"grpc.initial_reconnect_backoff_ms": buildGoogleGrpcIntChannelArg(GRPC_INITIAL_BACKOFF_MS),
+			"grpc.max_connection_age_ms":        buildGoogleGrpcIntChannelArg(GRPC_MAX_CONNECTION_AGE_MS),
+			"grpc.max_connection_age_grace_ms":  buildGoogleGrpcIntChannelArg(GRPC_MAX_CONNECTION_AGE_GRACE_MS),
 		},
 	}
 	iamConfig, err := anypb.New(&grpc_cred.AwsIamConfig{

--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -928,6 +928,8 @@ adsConfig:
           grpc.keepalive_time_ms: { intValue: "10000" }
           grpc.keepalive_timeout_ms: { intValue: "20000" }
           grpc.initial_reconnect_backoff_ms: { intValue: "10000" }
+          grpc.max_connection_age_ms: { intValue: "2400000" }
+          grpc.max_connection_age_grace_ms: { intValue: "5000" }
 
 cdsConfig:
   ads: {}
@@ -961,6 +963,8 @@ adsConfig:
           grpc.keepalive_time_ms: { intValue: "10000" }
           grpc.keepalive_timeout_ms: { intValue: "20000" }
           grpc.initial_reconnect_backoff_ms: { intValue: "10000" }
+          grpc.max_connection_age_ms: { intValue: "2400000" }
+          grpc.max_connection_age_grace_ms: { intValue: "5000" }
 
 cdsConfig:
   ads: {}
@@ -1010,6 +1014,8 @@ adsConfig:
           grpc.keepalive_time_ms: { intValue: "10000" }
           grpc.keepalive_timeout_ms: { intValue: "20000" }
           grpc.initial_reconnect_backoff_ms: { intValue: "10000" }
+          grpc.max_connection_age_ms: { intValue: "2400000" }
+          grpc.max_connection_age_grace_ms: { intValue: "5000" }
 
 cdsConfig:
   ads: {}
@@ -1056,6 +1062,8 @@ adsConfig:
           grpc.keepalive_time_ms: { intValue: "10000" }
           grpc.keepalive_timeout_ms: { intValue: "20000" }
           grpc.initial_reconnect_backoff_ms: { intValue: "10000" }
+          grpc.max_connection_age_ms: { intValue: "2400000" }
+          grpc.max_connection_age_grace_ms: { intValue: "5000" }
 
 cdsConfig:
   ads: {}

--- a/agent/resources/bootstrap_configs/relay_bootstrap.yaml
+++ b/agent/resources/bootstrap_configs/relay_bootstrap.yaml
@@ -64,7 +64,14 @@ static_resources:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           explicit_http_config:
-            http2_protocol_options: {}
+            http2_protocol_options: {
+              connection_keepalive: {
+                interval: 10s,
+                timeout: 5s
+              }
+            }
+          common_http_protocol_options:
+            max_connection_duration: 2400s  # Set to 40 mins to ensure this only triggers if control plane didn't already perform periodic connection termination
       lb_policy: round_robin
       per_connection_buffer_limit_bytes: $RELAY_BUFFER_LIMIT_BYTES
       load_assignment:


### PR DESCRIPTION


<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

There are two changes here:
- Add `keep_alive` settings at Relay for connection with EMS. 
- Add a `max_connection_age` for both relay and sidecar mode for connection with control plane

### Implementation details

#### Keep Alive Settings
Added following settings to the gRPC connection with EMS:
```
connection_keepalive: {
                interval: 10s,
                timeout: 5s
              }
```
This will detect if the connection with EMS is dead terminated abruptly by the server.

#### Max Connection Age Settings
#####  Relay <-> EMS connection
`max_connection_duration: 2400s` has been set to ensure that we reset this connection only if EMS doesn't gracefully terminate it within it's normal 30-35mins interval.

##### Sidecar Envoy <-> Relay connection
- We already have [stream_idle_timeout](https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/agent/config/agent_config.go#L75) configured on Relay listener settings that resets the stream. In addition, I've added `max_connection_age` and `max_connection_age_grace` settings to force the connection to be reset as well at the same 40 mins interval.

### Testing
In order to reproduce an dead connection scenario I followed below steps:
- Built a custom Envoy image in my personal account.
- Ran sidecar envoy and relay containers on my machine.
- Created a test envoy manifest in my account.
- Ran EMS locally.
- Reproduced the failure scenario by black holing traffic through iptable drop
```
Block Incoming Traffic: sudo iptables -A INPUT -p tcp --dport <server_port> -j DROP
Block Outgoing Traffic: sudo iptables -A OUTPUT -p tcp --sport <server_port> -j DROP
To restore traffic after the test:
sudo iptables -D INPUT -p tcp --dport <server_port> -j DROP
sudo iptables -D OUTPUT -p tcp --sport <server_port> -j DROP
```
#### Without the fix
- Confirmed that the Relay doesn't detect that and Sidecar envoy continues to show connected_state as 1 (connected)

#### With the fix
- Confirmed that the Relay detects the dead connection and the forces a reconnect.

##### Keep Alive fix:

**Relay logs**
```
[2026-01-15 22:12:04.285][28][debug][http2] [source/common/http/http2/codec_impl.cc:922] [Tags: "ConnectionId":"11"] Closing connection due to keepalive timeout
[2026-01-15 22:12:04.285][28][debug][connection] [source/common/network/connection_impl.cc:183] [Tags: "ConnectionId":"11"] closing data_to_write=0 type=1
[2026-01-15 22:12:04.285][28][debug][connection] [source/common/network/connection_impl.cc:314] [Tags: "ConnectionId":"11"] closing socket: 1
[2026-01-15 22:12:04.285][28][debug][client] [source/common/http/codec_client.cc:107] [Tags: "ConnectionId":"11"] disconnect. resetting 1 pending requests
[2026-01-15 22:12:04.285][28][debug][client] [source/common/http/codec_client.cc:159] [Tags: "ConnectionId":"11"] Request reset. Reason 7
[2026-01-15 22:12:04.285][28][debug][pool] [source/common/conn_pool/conn_pool_base.cc:254] [Tags: "ConnectionId":"11"] destroying stream: 0 active remaining, readyForStream false, currentUnusedCapacity 0
[2026-01-15 22:12:04.285][28][debug][router] [source/common/router/router.cc:1491] [Tags: "ConnectionId":"10","StreamId":"9819326820684159482"] upstream reset: reset reason: connection termination, transport failure reason:
[2026-01-15 22:12:04.285][28][debug][http] [source/common/http/filter_manager.cc:1029] [Tags: "ConnectionId":"10","StreamId":"9819326820684159482"] Resetting stream due to upstream_reset_after_response_started{connection_termination}. Prior headers have already been sent
```
**Sidecar logs:**
```
[2026-01-15 22:11:59.584][28][debug][main] [source/server/server.cc:245] flushing stats
[2026-01-15 22:12:04.285][28][debug][grpc] [source/common/grpc/google_async_client_impl.cc:434] Finish with grpc-status code 13
[2026-01-15 22:12:04.285][28][debug][grpc] [source/common/grpc/google_async_client_impl.cc:257] notifyRemoteClose 13 Received RST_STREAM with error code 0
[2026-01-15 22:12:04.285][28][warning][config] [./source/extensions/config_subscription/grpc/grpc_stream.h:188] StreamAggregatedResources gRPC config stream to unix:///var/run/ecs/relay/envoy_xds.sock closed: 13, Received RST_STREAM with error code 0
[2026-01-15 22:12:04.285][28][debug][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:125] gRPC update for type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment failed
[2026-01-15 22:12:04.285][28][debug][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:125] gRPC update for type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment failed
[2026-01-15 22:12:04.285][28][debug][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:125] gRPC update for type.googleapis.com/envoy.config.cluster.v3.Cluster failed
[2026-01-15 22:12:04.285][28][debug][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:125] gRPC update for type.googleapis.com/envoy.config.route.v3.RouteConfiguration failed
[2026-01-15 22:12:04.285][28][debug][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:125] gRPC update for type.googleapis.com/envoy.config.route.v3.RouteConfiguration failed
[2026-01-15 22:12:04.285][28][debug][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:125] gRPC update for type.googleapis.com/envoy.config.route.v3.RouteConfiguration failed
[2026-01-15 22:12:04.285][28][debug][config] [source/extensions/config_subscription/grpc/grpc_subscription_impl.cc:125] gRPC update for type.googleapis.com/envoy.config.listener.v3.Listener failed
[2026-01-15 22:12:04.286][28][debug][grpc] [source/common/grpc/google_async_client_impl.cc:473] Stream cleanup with 0 in-flight tags
[2026-01-15 22:12:04.286][28][debug][grpc] [source/common/grpc/google_async_client_impl.cc:462] Deferred delete
[2026-01-15 22:12:04.286][28][debug][grpc] [source/common/grpc/google_async_client_impl.cc:194] GoogleAsyncStreamImpl destruct
[2026-01-15 22:12:04.468][28][debug][config] [./source/extensions/config_subscription/grpc/grpc_stream.h:63] Establishing new gRPC bidi stream to unix:///var/run/ecs/relay/envoy_xds.sock for rpc StreamAggregatedResources(stream .envoy.service.discovery.v3.DiscoveryRequest) returns (stream .envoy.service.discovery.v3.DiscoveryResponse);

[2026-01-15 22:22:35.550][7][debug] [AppNet Agent] Envoy connectivity check status 200, {"stats":[{"name":"control_plane.connected_state","value":0}]}
```
**As soon as EMS was restarted and the iptable rules dropped, the Envoy reconnected**
```
[2026-01-15 22:23:15.614][7][debug] [AppNet Agent] Envoy connectivity check status 200, {"stats":[{"name":"control_plane.connected_state","value":1}]}
[2026-01-15 22:23:15.614][7][debug] [AppNet Agent] Control Plane connection state changed to: CONNECTED
```

##### Max Connection Age on Relay

```
[2026-01-20 21:45:03.179][7][error] [AppNet Agent] Envoy connectivity check failed with: Get "http://127.0.0.1:9901/stats?filter=control_plane.connected_state&format=json": dial tcp 127.0.0.1:9901: connect: connection refused
[2026-01-20 21:45:04.735][28][debug][pool] [source/common/conn_pool/conn_pool_base.cc:868] [Tags: "ConnectionId":"22"] max connection duration reached, start draining
[2026-01-20 21:45:07.750][21][debug][main] [source/server/server.cc:245] flushing stats
```
Relay closes the connection after the set duration but doesn't recreate it since sidecar doesn't send any requests.

##### Stream Idle Timeout

** Relay Logs:**
```
[2026-01-21 00:35:02.349][27][debug][http] [source/common/http/filter_manager.cc:1029] [Tags: "ConnectionId":"2","StreamId":"4823259037090761753"] Resetting stream due to stream_idle_timeout. Prior headers have already been sent
[2026-01-21 00:35:02.349][27][debug][http] [source/common/http/conn_manager_impl.cc:258] [Tags: "ConnectionId":"2","StreamId":"4823259037090761753"] doEndStream() resetting stream
[2026-01-21 00:35:02.349][27][debug][http] [source/common/http/conn_manager_impl.cc:1978] [Tags: "ConnectionId":"2","StreamId":"4823259037090761753"] stream reset: reset reason: local reset, response details: -
[2026-01-21 00:35:02.349][27][debug][http2] [source/common/http/http2/codec_impl.cc:1227] [Tags: "ConnectionId":"2"] sent reset code=0
[2026-01-21 00:35:02.349][27][debug][http2] [source/common/http/http2/codec_impl.cc:1386] [Tags: "ConnectionId":"2"] stream 91 closed: 0
[2026-01-21 00:35:02.349][27][debug][http2] [source/common/http/http2/codec_impl.cc:1449] [Tags: "ConnectionId":"2"] Recouping 0 bytes of flow control window for stream 91.
[2026-01-21 00:35:02.848][27][debug][http] [source/common/http/conn_manager_impl.cc:394] [Tags: "ConnectionId":"2"] new stream
[2026-01-21 00:35:02.848][27][debug][http] [source/common/http/conn_manager_impl.cc:1196] [Tags: "ConnectionId":"2","StreamId":"5817949914868880306"] request headers complete (end_stream=false):
':path', '/envoy.service.discovery.v3.AggregatedDiscoveryService/StreamAggregatedResources'
':authority', 'var%2Frun%2Fecs%2Frelay%2Fenvoy_xds.sock'
':method', 'POST'
':scheme', 'http'
'content-type', 'application/grpc'
'te', 'trailers'
'grpc-accept-encoding', 'identity, deflate, gzip'
'user-agent', 'grpc-c++/1.66.1 grpc-c/43.0.0 (linux; chttp2)'
```

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Enable keep alive settings on Relay and set max connection age for control plane connection

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
