### PR TITLE
Only set up local cluster in cluster manager for SC only

### DIFF
--- a/agent/envoy_bootstrap/envoy_bootstrap.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap.go
@@ -542,14 +542,17 @@ func buildLayeredRuntime() (*boot.LayeredRuntime, error) {
 	}, nil
 }
 
-func buildClusterManager() *boot.ClusterManager {
+func buildClusterManager(isServiceConnect bool) *boot.ClusterManager {
 	logPath := env.Or("ENVOY_OUTLIER_DETECTION_EVENT_LOG_PATH", "/dev/stdout")
-	return &boot.ClusterManager{
+	clusterManager := &boot.ClusterManager{
 		OutlierDetection: &boot.ClusterManager_OutlierDetection{
 			EventLogPath: logPath,
 		},
-		LocalClusterName: config.ENVOY_LOCAL_CLUSTER_NAME,
 	}
+	if isServiceConnect {
+		clusterManager.LocalClusterName = config.ENVOY_LOCAL_CLUSTER_NAME
+	}
+	return clusterManager
 }
 
 func buildFileDataSource(filename string) *core.DataSource {
@@ -1526,17 +1529,18 @@ func bootstrap(agentConfig config.AgentConfig, fileUtil FileUtil, envoyCLIInst E
 	}
 
 	zone := platforminfo.GetZoneId(metadata)
+	isServiceConnect := agentConfig.XdsEndpointUdsPath != ""
 
 	b := &boot.Bootstrap{
 		Admin:            admin,
 		Node:             buildNode(id, clusterId, region, zone, metadata),
 		LayeredRuntime:   lr,
 		DynamicResources: dr,
-		ClusterManager:   buildClusterManager(),
+		ClusterManager:   buildClusterManager(isServiceConnect),
 	}
 
 	// append Static cluster for service connect only
-	if agentConfig.XdsEndpointUdsPath != "" {
+	if isServiceConnect {
 		appendStaticLocalCluster(b)
 	}
 

--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -872,17 +872,25 @@ layers:
 
 func TestBuildClusterManager(t *testing.T) {
 	setup()
-	checkMessage(t, buildClusterManager(), `
+	checkMessage(t, buildClusterManager(true), `
 outlierDetection:
   eventLogPath: /dev/stdout
 localClusterName: `+config.ENVOY_LOCAL_CLUSTER_NAME+`
 `)
 }
 
+func TestBuildClusterManager_noServiceConnect(t *testing.T) {
+	setup()
+	checkMessage(t, buildClusterManager(false), `
+outlierDetection:
+  eventLogPath: /dev/stdout
+`)
+}
+
 func TestBuildClusterManager_CustomOutlierDetection(t *testing.T) {
 	setup()
 	os.Setenv("ENVOY_OUTLIER_DETECTION_EVENT_LOG_PATH", "/custom/path")
-	checkMessage(t, buildClusterManager(), `
+	checkMessage(t, buildClusterManager(true), `
 outlierDetection:
   eventLogPath: /custom/path
 localClusterName: `+config.ENVOY_LOCAL_CLUSTER_NAME+`


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->

For AppMesh, we don't want to set up local cluster in cluster manager, because it will fail:
January 28, 2026, 10:31
[2026-01-28 18:31:29.906][61][critical][main] [source/server/server.cc:422] error initializing config ' /tmp/envoy-config-1036453825.yaml': local cluster 'local_cluster' must be defined

This is caused by that static local cluster is only set for SC use case.


### Implementation details
<!-- How are the changes implemented? -->
Check if it's sc and neglect local cluster

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
Please ensure unit and integration tests pass (on at least one platform) before opening the pull request.
Once you open the pull request, there will be several automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it.
-->
make build

New tests cover the changes: <!-- yes|no -->
yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Set up local cluster in cluster manager for SC only

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
