### PR TITLE
Add a FIPS_MODE_ENABLED environment variable

### DIFF
--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -3156,3 +3156,94 @@ func TestRelayBootstrap_NotFipsCompatibleInIsoCloud(t *testing.T) {
 	v, e := GetRelayBootstrapYaml(agentConfig, mockFileUtil, mockEnvoyCLI)
 	assertError(t, v, e)
 }
+
+func TestBuildMetadataForNode_FipsModeEnabled_NotSet(t *testing.T) {
+	setup()
+	metadata, err := buildMetadataForNode()
+	assert.Nil(t, err)
+	// When FIPS_MODE_ENABLED is not set or false, fipsModeEnabled should not be in metadata
+	if metadata != nil {
+		metadataMap := metadata.AsMap()
+		if platformInfo, exists := metadataMap["aws.appmesh.platformInfo"]; exists {
+			platformMap := platformInfo.(map[string]interface{})
+			_, fipsExists := platformMap["fipsModeEnabled"]
+			assert.False(t, fipsExists, "fipsModeEnabled should not exist when not set")
+		}
+	}
+}
+
+func TestBuildMetadataForNode_FipsModeEnabled_TruthyValues(t *testing.T) {
+	setup()
+	testCases := []struct {
+		value string
+	}{
+		{"1"},
+		{"true"},
+		{"TRUE"},
+	}
+
+	for _, tc := range testCases {
+		os.Setenv("FIPS_MODE_ENABLED", tc.value)
+		metadata, err := buildMetadataForNode()
+		assert.Nil(t, err)
+
+		expectedYaml := `
+id: id
+cluster: cluster
+locality:
+  region: us-west-2
+  zone: use1-az1
+metadata:
+  aws.appmesh.platformInfo:
+    fipsModeEnabled: true
+`
+		checkMessageSupersetMatch(t, buildNode("id", "cluster", "us-west-2", "use1-az1", metadata), expectedYaml)
+		os.Unsetenv("FIPS_MODE_ENABLED")
+	}
+}
+
+func TestBuildMetadataForNode_FipsModeEnabled_FalsyValues(t *testing.T) {
+	setup()
+	testCases := []struct {
+		value string
+	}{
+		{"0"},
+		{"false"},
+		{"FALSE"},
+	}
+
+	for _, tc := range testCases {
+		os.Setenv("FIPS_MODE_ENABLED", tc.value)
+		metadata, err := buildMetadataForNode()
+		assert.Nil(t, err)
+
+		// When false, fipsModeEnabled should not be in metadata
+		if metadata != nil {
+			metadataMap := metadata.AsMap()
+			if platformInfo, exists := metadataMap["aws.appmesh.platformInfo"]; exists {
+				platformMap := platformInfo.(map[string]interface{})
+				_, fipsExists := platformMap["fipsModeEnabled"]
+				assert.False(t, fipsExists, "fipsModeEnabled should not exist when false")
+			}
+		}
+		os.Unsetenv("FIPS_MODE_ENABLED")
+	}
+}
+
+func TestBuildMetadataForNode_FipsModeEnabled_InvalidValue(t *testing.T) {
+	setup()
+	os.Setenv("FIPS_MODE_ENABLED", "invalid")
+	defer os.Unsetenv("FIPS_MODE_ENABLED")
+	metadata, err := buildMetadataForNode()
+	// The function should still succeed but the platformInfo should not contain fipsModeEnabled
+	assert.Nil(t, err)
+	// Check that the metadata doesn't contain the platformInfo with fipsModeEnabled
+	if metadata != nil {
+		metadataMap := metadata.AsMap()
+		if platformInfo, exists := metadataMap["aws.appmesh.platformInfo"]; exists {
+			platformMap := platformInfo.(map[string]interface{})
+			_, fipsExists := platformMap["fipsModeEnabled"]
+			assert.False(t, fipsExists, "fipsModeEnabled should not exist when invalid value is provided")
+		}
+	}
+}

--- a/agent/envoy_bootstrap/platforminfo/platform_info_collector.go
+++ b/agent/envoy_bootstrap/platforminfo/platform_info_collector.go
@@ -65,6 +65,7 @@ const (
 	AvailabilityZoneKey         = "AvailabilityZone"
 	AvailabilityZoneIDKey       = "AvailabilityZoneID"
 	supportedIPFamiliesKey      = "supportedIPFamilies"
+	fipsModeEnabledKey          = "fipsModeEnabled"
 	ec2MetadataTokenResource    = "/latest/api/token"
 	ec2ImdsTokenHeader          = "X-aws-ec2-metadata-token"
 	ec2ImdsTokenTtlHeader       = "X-aws-ec2-metadata-token-ttl-seconds"
@@ -185,6 +186,13 @@ func BuildMetadata() (*map[string]interface{}, error) {
 	buildMetadataForK8sPlatform(mapping)
 	buildMetadataForEcsPlatform(mapping)
 	buildMetadataFromSystemInfo(mapping)
+
+	if fipsModeEnabled, err := env.TruthyOrElse("FIPS_MODE_ENABLED", false); err != nil {
+		log.Warnf("Could not parse value for FIPS_MODE_ENABLED: %v", err)
+		return nil, err
+	} else if fipsModeEnabled {
+		mapping[fipsModeEnabledKey] = fipsModeEnabled
+	}
 
 	if len(mapping) != 0 {
 		md[metadataNamespace] = mapping


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
Added support for FIPS mode configuration through the `FIPS_MODE_ENABLED` environment variable. This allows the agent to indicate whether FIPS mode is enabled in the platform metadata sent to the management server.

### Implementation details
- Added `FIPS_MODE_ENABLED` environment variable support in platform info collector
- Variable accepts truthy values (1, true, TRUE) or falsy values (0, false, FALSE)
- Defaults to not `false` when not set. *When it's false or not set, we **don't add** it to the metadata sent to EMS*.
- Invalid values are handled gracefully with a warning
- Added comprehensive test coverage for all scenarios (not set, truthy/falsy values, invalid values)
- Updated README.md with environment variable documentation

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
Please ensure unit and integration tests pass (on at least one platform) before opening the pull request.
Once you open the pull request, there will be several automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it.
-->
All new tests pass:
- `TestBuildMetadataForNode_FipsModeEnabled_NotSet`
- `TestBuildMetadataForNode_FipsModeEnabled_TruthyValues`
- `TestBuildMetadataForNode_FipsModeEnabled_FalsyValues`
- `TestBuildMetadataForNode_FipsModeEnabled_InvalidValue`

New tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Add a FIPS_MODE_ENABLED environment variable

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
