### PR TITLE
Add a APPNET_FIPS_MODE_ENABLED environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ These environment variables are used to pass operating platform/environment info
 |`APPMESH_PLATFORM_K8S_POD_UID`  | `arn:aws:ecs:region:aws_account_id:container-instance/cluster-name/container-instance-id` | For Envoy running on K8s, Pod UID injected by App Mesh Controller. |  |
 |`APPNET_CONTAINER_IP_MAPPING`  | `{"App1":"172.10.1.1","App2":"172.10.1.2"}` | Specifies address mapping of application container as set by ECS agent in ECS Service Connect. |  |
 |`APPNET_LISTENER_PORT_MAPPING`  | `{"Listener1":15000,"Listener2":15001}` | Specifies port mapping for each application port as set by ECS agent in ECS Service Connect. |  |
+|`APPNET_FIPS_MODE_ENABLED`  | <0 &#124; 1 &#124; true &#124; false> | Indicates whether FIPS mode is enabled for the platform. Accepts truthy values (1, true, TRUE) or falsy values (0, false, FALSE). | false |
 
 ### Deprecated
 

--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -3161,7 +3161,7 @@ func TestBuildMetadataForNode_FipsModeEnabled_NotSet(t *testing.T) {
 	setup()
 	metadata, err := buildMetadataForNode()
 	assert.Nil(t, err)
-	// When FIPS_MODE_ENABLED is not set or false, fipsModeEnabled should not be in metadata
+	// When APPNET_FIPS_MODE_ENABLED is not set or false, fipsModeEnabled should not be in metadata
 	if metadata != nil {
 		metadataMap := metadata.AsMap()
 		if platformInfo, exists := metadataMap["aws.appmesh.platformInfo"]; exists {
@@ -3183,7 +3183,7 @@ func TestBuildMetadataForNode_FipsModeEnabled_TruthyValues(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		os.Setenv("FIPS_MODE_ENABLED", tc.value)
+		os.Setenv("APPNET_FIPS_MODE_ENABLED", tc.value)
 		metadata, err := buildMetadataForNode()
 		assert.Nil(t, err)
 
@@ -3198,7 +3198,7 @@ metadata:
     fipsModeEnabled: true
 `
 		checkMessageSupersetMatch(t, buildNode("id", "cluster", "us-west-2", "use1-az1", metadata), expectedYaml)
-		os.Unsetenv("FIPS_MODE_ENABLED")
+		os.Unsetenv("APPNET_FIPS_MODE_ENABLED")
 	}
 }
 
@@ -3213,7 +3213,7 @@ func TestBuildMetadataForNode_FipsModeEnabled_FalsyValues(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		os.Setenv("FIPS_MODE_ENABLED", tc.value)
+		os.Setenv("APPNET_FIPS_MODE_ENABLED", tc.value)
 		metadata, err := buildMetadataForNode()
 		assert.Nil(t, err)
 
@@ -3226,14 +3226,14 @@ func TestBuildMetadataForNode_FipsModeEnabled_FalsyValues(t *testing.T) {
 				assert.False(t, fipsExists, "fipsModeEnabled should not exist when false")
 			}
 		}
-		os.Unsetenv("FIPS_MODE_ENABLED")
+		os.Unsetenv("APPNET_FIPS_MODE_ENABLED")
 	}
 }
 
 func TestBuildMetadataForNode_FipsModeEnabled_InvalidValue(t *testing.T) {
 	setup()
-	os.Setenv("FIPS_MODE_ENABLED", "invalid")
-	defer os.Unsetenv("FIPS_MODE_ENABLED")
+	os.Setenv("APPNET_FIPS_MODE_ENABLED", "invalid")
+	defer os.Unsetenv("APPNET_FIPS_MODE_ENABLED")
 	metadata, err := buildMetadataForNode()
 	// The function should still succeed but the platformInfo should not contain fipsModeEnabled
 	assert.Nil(t, err)

--- a/agent/envoy_bootstrap/platforminfo/platform_info_collector.go
+++ b/agent/envoy_bootstrap/platforminfo/platform_info_collector.go
@@ -187,8 +187,8 @@ func BuildMetadata() (*map[string]interface{}, error) {
 	buildMetadataForEcsPlatform(mapping)
 	buildMetadataFromSystemInfo(mapping)
 
-	if fipsModeEnabled, err := env.TruthyOrElse("FIPS_MODE_ENABLED", false); err != nil {
-		log.Warnf("Could not parse value for FIPS_MODE_ENABLED: %v", err)
+	if fipsModeEnabled, err := env.TruthyOrElse("APPNET_FIPS_MODE_ENABLED", false); err != nil {
+		log.Warnf("Could not parse value for APPNET_FIPS_MODE_ENABLED: %v", err)
 		return nil, err
 	} else if fipsModeEnabled {
 		mapping[fipsModeEnabledKey] = fipsModeEnabled


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Quick follow up to https://github.com/aws/amazon-ecs-service-connect-agent/pull/136 to rename FIPS_MODE_ENABLED environment variable to APPNET_FIPS_MODE_ENABLED and add to README.


<!--
Note for external contributors:
Please ensure unit and integration tests pass (on at least one platform) before opening the pull request.
Once you open the pull request, there will be several automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it.
-->

Existing tests cover the changes: <!-- yes|no --> yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Add FIPS_MODE_ENABLED environment variable to the README

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
