### PR TITLE
Set TLS ECDH curve in relay bootstrap config per partition

### DIFF
--- a/agent/envoy_bootstrap/envoy_bootstrap.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap.go
@@ -1713,6 +1713,13 @@ func setRelayBootstrapEnvVariables(agentConfig config.AgentConfig, envoyCLIInst 
 		os.Setenv("ENVOY_USE_HTTP_CLIENT_TO_FETCH_AWS_CREDENTIALS", fmt.Sprint(agentConfig.EnvoyUseHttpClientToFetchAwsCredentials))
 	}
 
+	region := os.Getenv("AWS_REGION")
+	if strings.HasPrefix(region, "us-isof-") || strings.HasPrefix(region, "eu-isoe-") {
+		os.Setenv("TLS_CURVE", "P-384")
+	} else {
+		os.Setenv("TLS_CURVE", "P-256")
+	}
+
 	return nil
 }
 

--- a/agent/resources/bootstrap_configs/relay_bootstrap.yaml
+++ b/agent/resources/bootstrap_configs/relay_bootstrap.yaml
@@ -87,6 +87,9 @@ static_resources:
             validation_context:
               trusted_ca:
                 filename: /etc/pki/tls/cert.pem
+            tls_params:
+              ecdh_curves:
+                - $TLS_CURVE
           sni: $APPNET_MANAGEMENT_DOMAIN_NAME
 
 admin:


### PR DESCRIPTION
### Summary
Configure TLS ECDH curve in relay bootstrap based on AWS partition. `aws-iso-f` and `aws-iso-e` partitions require `P-384`, all other partitions use the default `P-256`.

### Implementation details
- Added `tls_params` with `ecdh_curves` to `relay_bootstrap.yaml` using a new `$TLS_CURVE` environment variable
- In `setRelayBootstrapEnvVariables`, set `TLS_CURVE` to `P-384` for regions matching `us-isof-*` or `eu-isoe-*`, and `P-256` for all other regions
- The existing `os.ExpandEnv` substitution in `GetRelayBootstrapYaml` handles the replacement — no changes needed to the config rendering pipeline

### Testing
- Verified all existing relay bootstrap unit tests pass
- Built a test container image with the modified agent binary and bootstrap config
- Ran with `AWS_REGION=us-west-2` — confirmed generated config contains `ecdh_curves: P-256`
- Ran with `AWS_REGION=us-isof-south-1` — confirmed generated config contains `ecdh_curves: P-384`

New tests cover the changes: no new tests added

### Description for the changelog
Set TLS ECDH curve to P-384 for aws-iso-f and aws-iso-e partitions in relay bootstrap config.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.