### PR TITLE
Fix: Handle metrics reset on Envoy restart in delta computation

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -225,7 +225,7 @@ func setAgentCapabilities() error {
 }
 
 // start the command object, restarting up to the configured limit
-func keepCommandAlive(agentConfig config.AgentConfig, messageSource *messagesources.MessageSources) {
+func keepCommandAlive(agentConfig config.AgentConfig, messageSource *messagesources.MessageSources, snapshotter *stats.Snapshotter) {
 	var restartCount int = 0
 
 	// If we are exiting this function, then we should exit the agent.  ECS
@@ -238,6 +238,13 @@ func keepCommandAlive(agentConfig config.AgentConfig, messageSource *messagesour
 
 		// Build the command line arguments and execute the program
 		cmdArgs := buildCommandArgs(agentConfig)
+
+		// Reset the stats snapshot before restarting Envoy. Envoy's counters will reset
+		// to zero on restart, so the old snapshot must be discarded to avoid computing
+		// deltas against stale pre-restart values.
+		if snapshotter != nil {
+			snapshotter.ResetSnapshot()
+		}
 
 		pid, err := startCommand(agentConfig, cmdArgs)
 		if err != nil {
@@ -610,7 +617,7 @@ func main() {
 	setupUdsForEnvoyAdmin(agentConfig, &messageSources)
 
 	// Start the configured binary and keep it alive
-	go keepCommandAlive(agentConfig, &messageSources)
+	go keepCommandAlive(agentConfig, &messageSources, &snapshotter)
 	defer stopProcesses(agentConfig.StopProcessWaitTime, &messageSources)
 
 	go healthStatus.StartHealthCheck(agentStartTime, agentConfig, &messageSources)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -209,7 +209,7 @@ func TestKeepCommandAlive(t *testing.T) {
 
 	start := time.Now()
 
-	go keepCommandAlive(agentConfig, &messageSources)
+	go keepCommandAlive(agentConfig, &messageSources, nil)
 
 	for {
 		loopElapsed := time.Since(start)
@@ -253,7 +253,7 @@ func TestKeepCommandAliveWithRestart(t *testing.T) {
 
 	start := time.Now()
 
-	go keepCommandAlive(agentConfig, &messageSources)
+	go keepCommandAlive(agentConfig, &messageSources, nil)
 
 	// one initial start and EnvoyRestartCount additional pids
 	expectedPids := agentConfig.EnvoyRestartCount + 1
@@ -458,7 +458,7 @@ func TestLoggingToFileWithCommandExecution(t *testing.T) {
 	messageSources.SetupChannels()
 
 	// We just need the command to run.  This won't take long
-	go keepCommandAlive(agentConfig, &messageSources)
+	go keepCommandAlive(agentConfig, &messageSources, nil)
 	time.Sleep(250 * time.Millisecond)
 
 	syscall.Sync()
@@ -539,7 +539,7 @@ func skip_TestLogRotation(t *testing.T) {
 	var messageSources messagesources.MessageSources
 	messageSources.SetupChannels()
 
-	go keepCommandAlive(agentConfig, &messageSources)
+	go keepCommandAlive(agentConfig, &messageSources, nil)
 
 	// Run for 10 seconds to give ample time for data to accumulate
 	time.Sleep(10 * time.Second)

--- a/agent/stats/snapshotter.go
+++ b/agent/stats/snapshotter.go
@@ -36,6 +36,13 @@ type Snapshotter struct {
 	HttpRequest *retryablehttp.Request
 }
 
+// ResetSnapshot clears the previous snapshot so the next delta computation treats
+// the next snapshot as the first one.
+func (snapshotter *Snapshotter) ResetSnapshot() {
+	snapshotter.Snapshot = nil
+	log.Info("Snapshot reset due to Envoy process exit.")
+}
+
 func (snapshotter *Snapshotter) StartSnapshot(agentConfig config.AgentConfig) {
 	httpClient, err := client.CreateRetryableHttpClientForEnvoyServer(agentConfig)
 	httpClient.HTTPClient.Timeout = EnvoyStatsClientHttpTimeout

--- a/agent/stats/snapshotter_test.go
+++ b/agent/stats/snapshotter_test.go
@@ -184,3 +184,82 @@ func TestComputeDeltaForMetricFamily(t *testing.T) {
 	assert.NotNil(t, deltaMetricFamily.Metric[0].Gauge)
 	assert.Equal(t, float64(5), deltaMetricFamily.Metric[0].Gauge.GetValue())
 }
+
+func TestResetSnapshot(t *testing.T) {
+	snapshotter := Snapshotter{}
+
+	input1 := []byte("# TYPE RequestCount counter\n" +
+		"RequestCount{Service=\"svc\"} 10\n")
+	snapshot1, err := parsePrometheusStats(input1)
+	assert.NoError(t, err)
+
+	snapshotter.computeDelta(snapshot1)
+	snapshotter.Snapshot = snapshot1
+	assert.NotNil(t, snapshotter.Snapshot)
+	assert.NotNil(t, snapshotter.Delta)
+
+	input2 := []byte("# TYPE RequestCount counter\n" +
+		"RequestCount{Service=\"svc\"} 20\n")
+	snapshot2, err := parsePrometheusStats(input2)
+	assert.NoError(t, err)
+
+	snapshotter.computeDelta(snapshot2)
+	snapshotter.Snapshot = snapshot2
+	assert.Equal(t, float64(10), snapshotter.Delta["RequestCount"].Metric[0].Counter.GetValue())
+
+	// Envoy dies, ResetSnapshot is called before new Envoy starts
+	snapshotter.ResetSnapshot()
+	assert.Nil(t, snapshotter.Snapshot)
+
+	// New Envoy starts, counters reset to zero
+	input3 := []byte("# TYPE RequestCount counter\n" +
+		"RequestCount{Service=\"svc\"} 5\n")
+	snapshot3, err := parsePrometheusStats(input3)
+	assert.NoError(t, err)
+
+	snapshotter.computeDelta(snapshot3)
+	snapshotter.Snapshot = snapshot3
+
+	// Delta should be 5 (the raw new value), not 5 - 20 = -15
+	assert.Equal(t, float64(5), snapshotter.Delta["RequestCount"].Metric[0].Counter.GetValue())
+}
+
+func TestResetSnapshotHistogram(t *testing.T) {
+	snapshotter := Snapshotter{}
+
+	input1 := []byte("# TYPE TargetResponseTime histogram\n" +
+		"TargetResponseTime_bucket{Service=\"svc\",le=\"5\"} 30\n" +
+		"TargetResponseTime_bucket{Service=\"svc\",le=\"+Inf\"} 50\n" +
+		"TargetResponseTime_sum{Service=\"svc\"} 100.0\n" +
+		"TargetResponseTime_count{Service=\"svc\"} 50\n")
+	snapshot1, err := parsePrometheusStats(input1)
+	assert.NoError(t, err)
+
+	snapshotter.computeDelta(snapshot1)
+	snapshotter.Snapshot = snapshot1
+
+	// Envoy dies, ResetSnapshot is called
+	snapshotter.ResetSnapshot()
+	assert.Nil(t, snapshotter.Snapshot)
+
+	// New Envoy starts with reset counters
+	input2 := []byte("# TYPE TargetResponseTime histogram\n" +
+		"TargetResponseTime_bucket{Service=\"svc\",le=\"5\"} 3\n" +
+		"TargetResponseTime_bucket{Service=\"svc\",le=\"+Inf\"} 5\n" +
+		"TargetResponseTime_sum{Service=\"svc\"} 12.5\n" +
+		"TargetResponseTime_count{Service=\"svc\"} 5\n")
+	snapshot2, err := parsePrometheusStats(input2)
+	assert.NoError(t, err)
+
+	snapshotter.computeDelta(snapshot2)
+	snapshotter.Snapshot = snapshot2
+
+	name := "TargetResponseTime"
+	histogram := snapshotter.Delta[name].Metric[0].Histogram
+
+	// All values should be the raw new values, not deltas against the old snapshot
+	assert.Equal(t, uint64(3), histogram.Bucket[0].GetCumulativeCount())
+	assert.Equal(t, uint64(5), histogram.Bucket[1].GetCumulativeCount())
+	assert.Equal(t, uint64(5), histogram.GetSampleCount())
+	assert.Equal(t, 12.5, histogram.GetSampleSum())
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Fix negative and overflowed metrics in delta computation when Envoy is killed and restarted.

### Implementation details
<!-- How are the changes implemented? -->
When Envoy is killed and restarted, its counters reset to zero. However, the snapshotter computes deltas by subtracting the old snapshot from the new one (new - old), without being aware that Envoy has restarted. This causes:
- Negative values for float64 counters
- Wrapped values near UINT64_MAX for uint64 histogram bucket counts and sample counts due to unsigned integer underflow

The fix resets the snapshot when an Envoy process dies, before starting up a new Envoy process. This ensures the next delta computation treats the post-restart metrics as a fresh baseline rather than comparing them against stale pre-restart values.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
Please ensure unit and integration tests pass (on at least one platform) before opening the pull request.
Once you open the pull request, there will be several automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it.
-->
Manually tested by deploying a custom agent binary to an ECS task, sending traffic, killing Envoy, sending more traffic, and verifying the `/stats/prometheus?usedonly&filter=metrics_extension&delta` endpoint returns correct non-negative values after restart.

Delta output after killing Envoy, before fix:
```
# TYPE HTTPCode_Target_2XX_Count counter
HTTPCode_Target_2XX_Count{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend"} -112

# TYPE RequestCountPerTarget counter
RequestCountPerTarget{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend"} -112

# TYPE TargetProcessedBytes counter
TargetProcessedBytes{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend"} -35141

# TYPE TargetResponseTime histogram
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="0.5"} 0
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="1"} 0
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="5"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="10"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="25"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="50"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="100"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="250"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="500"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="1000"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="2500"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="5000"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="10000"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="30000"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="60000"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="300000"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="600000"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="1.8e+06"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="3.6e+06"} 1.8446744073709552e+19
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="+Inf"} 1.8446744073709552e+19
TargetResponseTime_sum{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend"} -282.95
TargetResponseTime_count{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend"} 1.8446744073709552e+19
```

Delta output after killing Envoy, after fix:
```
# TYPE HTTPCode_Target_2XX_Count counter
HTTPCode_Target_2XX_Count{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend"} 6

# TYPE RequestCountPerTarget counter
RequestCountPerTarget{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend"} 6

# TYPE TargetProcessedBytes counter
TargetProcessedBytes{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend"} 1842

# TYPE TargetResponseTime histogram
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="0.5"} 0
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="1"} 0
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="5"} 5
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="10"} 5
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="25"} 5
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="50"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="100"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="250"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="500"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="1000"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="2500"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="5000"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="10000"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="30000"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="60000"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="300000"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="600000"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="1.8e+06"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="3.6e+06"} 6
TargetResponseTime_bucket{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend",le="+Inf"} 6
TargetResponseTime_sum{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend"} 39.75
TargetResponseTime_count{ClusterName="my-cluster",Direction="egress",ServiceName="my-service",TargetDiscoveryName="my-backend"} 6
```

New tests cover the changes: Yes
- TestResetSnapshot: Simulates normal operation → Envoy dies → ResetSnapshot() → New Envoy with reset counters, verifies delta uses raw new value
- TestResetSnapshotHistogram: Same flow for histograms, verifies bucket counts, sample count, and sample sum are correct after reset
```
=== RUN   TestResetSnapshot
time="2026-04-13T20:54:05Z" level=info msg="Snapshot reset due to Envoy process exit."
--- PASS: TestResetSnapshot (0.00s)
=== RUN   TestResetSnapshotHistogram
time="2026-04-13T20:54:05Z" level=info msg="Snapshot reset due to Envoy process exit."
--- PASS: TestResetSnapshotHistogram (0.00s)
PASS
ok      github.com/aws/aws-app-mesh-agent/agent/stats   0.716s
GOPATH=/build
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -ldflags "-w -s"
```

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Fix negative and overflowed service connect metrics by resetting snapshots on Envoy restarts.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
