### PR TITLE
Adds a race detector target to the Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ To send us a pull request, please:
 
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
+3. Ensure local tests pass, including the race detector (`make test-race` or `./docker-build.sh test-race`). If you are adding new concurrent code or modifying shared state, ensure your changes are covered by tests that exercise the concurrent paths so the race detector can catch issues.
 4. Commit to your fork using clear commit messages.
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-.PHONY: build format test go-build clean run vendor
+.PHONY: build format test test-race go-build clean run vendor
 
 OSARCH = $(shell arch)
 ifeq ($(OSARCH), x86_64)
@@ -48,6 +48,9 @@ format: $(SRCS)
 
 test: $(SRCS) format
 	go test -mod=vendor -count=1 -v ./...
+
+test-race: $(SRCS) format
+	go test -mod=vendor -count=1 -race -v ./...
 
 go-build: $(SRCS) format
 	GOPATH=$(shell pwd)


### PR DESCRIPTION
### Summary
This adds a target for running tests with race detection enabled. We currently have a couple of failures so I did not make it the default.

### Implementation details
Adds a new test-race target in the makefile

### Testing
I ran this against the current code and identified a couple of race conditions. 

New tests cover the changes: n/a

### Description for the changelog
Updated Makefile to include a race detection target

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
