### PR TITLE
Fix: Prevent race conditions in stats snapshot creation

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/aws-app-mesh-agent/agent/messagesources"
 	"github.com/aws/aws-app-mesh-agent/agent/server"
 	"github.com/aws/aws-app-mesh-agent/agent/stats"
+	"github.com/aws/aws-app-mesh-agent/agent/stats/snapshot"
 	cap "kernel.org/pub/linux/libs/security/libcap/cap"
 
 	log "github.com/sirupsen/logrus"
@@ -225,7 +226,7 @@ func setAgentCapabilities() error {
 }
 
 // start the command object, restarting up to the configured limit
-func keepCommandAlive(agentConfig config.AgentConfig, messageSource *messagesources.MessageSources, snapshotter *stats.Snapshotter) {
+func keepCommandAlive(agentConfig config.AgentConfig, messageSource *messagesources.MessageSources, snapshotter *snapshot.Snapshotter) {
 	var restartCount int = 0
 
 	// If we are exiting this function, then we should exit the agent.  ECS
@@ -384,7 +385,7 @@ func gracefullyDrainEnvoyListeners(agentConfig config.AgentConfig) {
 
 func setupHttpServer(agentConfig config.AgentConfig,
 	healthStatus *healthcheck.HealthStatus,
-	snapshotter *stats.Snapshotter,
+	snapshotter *snapshot.Snapshotter,
 	messageSources *messagesources.MessageSources) {
 
 	if agentConfig.AgentAdminMode == config.UDS {
@@ -579,7 +580,7 @@ func main() {
 	var messageSources messagesources.MessageSources
 	var agentConfig config.AgentConfig
 	var healthStatus healthcheck.HealthStatus
-	var snapshotter stats.Snapshotter
+	var snapshotter snapshot.Snapshotter
 
 	agentConfig.ParseFlags(os.Args)
 	agentConfig.SetDefaults()
@@ -623,7 +624,7 @@ func main() {
 	go healthStatus.StartHealthCheck(agentStartTime, agentConfig, &messageSources)
 	if agentConfig.EnableStatsSnapshot {
 		log.Debug("Enabling stats snapshot...")
-		go snapshotter.StartSnapshot(agentConfig)
+		go stats.StartSnapshot(&snapshotter, agentConfig)
 	}
 
 	// Start the agent http server only if APPNET_AGENT_ADMIN_MODE is set

--- a/agent/stats/envoy_prometheus_stats.go
+++ b/agent/stats/envoy_prometheus_stats.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/aws/aws-app-mesh-agent/agent/client"
 	"github.com/aws/aws-app-mesh-agent/agent/config"
+	"github.com/aws/aws-app-mesh-agent/agent/stats/snapshot"
 
 	// reference: https://github.com/prometheus/common/blob/main/expfmt/text_parse.go#L25
 	"github.com/prometheus/client_golang/prometheus"
@@ -38,7 +39,7 @@ type EnvoyPrometheusStatsHandler struct {
 	AgentConfig     config.AgentConfig
 	Limiter         *rate.Limiter
 	QueryParameters url.Values
-	Snapshotter     *Snapshotter
+	Snapshotter     *snapshot.Snapshotter
 }
 
 const (
@@ -81,13 +82,16 @@ func (envoyPrometheusStatsHandler *EnvoyPrometheusStatsHandler) HandleStats(resW
 	}
 
 	// If the Delta exists, we would just return Delta directly with no further operation needed.
-	if envoyPrometheusStatsHandler.QueryParameters.Has(deltaQueryKey) && envoyPrometheusStatsHandler.Snapshotter.Delta != nil {
-		resWriter.WriteHeader(http.StatusOK)
-		err := writeMetricsToResponse(resWriter, envoyPrometheusStatsHandler.Snapshotter.Delta)
-		if err != nil {
-			log.Errorf("error while writing response: %s", err)
+	if envoyPrometheusStatsHandler.QueryParameters.Has(deltaQueryKey) {
+		delta := envoyPrometheusStatsHandler.Snapshotter.GetDelta()
+		if delta != nil {
+			resWriter.WriteHeader(http.StatusOK)
+			err := writeMetricsToResponse(resWriter, delta)
+			if err != nil {
+				log.Errorf("error while writing response: %s", err)
+			}
+			return
 		}
-		return
 	}
 
 	// If Delta is not yet computed, most likely it is too early and we don't yet have two snapshots to compute the

--- a/agent/stats/envoy_prometheus_stats_test.go
+++ b/agent/stats/envoy_prometheus_stats_test.go
@@ -28,12 +28,13 @@ import (
 	"github.com/aws/aws-app-mesh-agent/agent/client"
 	"github.com/aws/aws-app-mesh-agent/agent/config"
 	"github.com/aws/aws-app-mesh-agent/agent/internal/netlistenertest"
+	"github.com/aws/aws-app-mesh-agent/agent/stats/snapshot"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/time/rate"
 )
 
-func buildHandlerWithSnapshotter(agentConfig config.AgentConfig, snapshotter *Snapshotter) EnvoyPrometheusStatsHandler {
+func buildHandlerWithSnapshotter(agentConfig config.AgentConfig, snapshotter *snapshot.Snapshotter) EnvoyPrometheusStatsHandler {
 	return EnvoyPrometheusStatsHandler{
 		AgentConfig: agentConfig,
 		Limiter:     rate.NewLimiter(config.TPS_LIMIT, config.BURST_TPS_LIMIT),
@@ -278,9 +279,9 @@ func TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_Si
 
 	var agentConfig config.AgentConfig
 	agentConfig.SetDefaults()
-	var snapshotter Snapshotter
+	var snapshotter snapshot.Snapshotter
 	envoyStatsHandler := buildHandlerWithSnapshotter(agentConfig, &snapshotter)
-	assert.Nil(t, snapshotter.Delta)
+	assert.Nil(t, snapshotter.GetDelta())
 
 	// Update EnvoyServer info to honor the mock Envoy server
 	envoyUrl, err := url.Parse(envoy.URL)
@@ -299,14 +300,14 @@ func TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_Si
 	snapshotter.HttpRequest, err = client.CreateRetryableAgentRequest(http.MethodGet, statsUrl, nil)
 	assert.NoError(t, err)
 	// Make one snapshot, then call computeDelta
-	snapshotter.makeSnapshot()
+	MakeSnapshot(&snapshotter)
 
 	filterParam := fmt.Sprintf("%s=%s", filterQueryKey, QuerySet[filterQueryKey])
 	requestUrl := fmt.Sprintf("%s?%s&%s&%s", statsServer.URL, filterParam, usedOnlyQueryKey, deltaQueryKey)
 
 	// Expecting Delta value equals to 0 and Delta object equals to the very first snapshot
-	assert.NotNil(t, snapshotter.Delta)
-	assert.Equal(t, snapshotter.Delta, snapshotter.Snapshot)
+	assert.NotNil(t, snapshotter.GetDelta())
+	assert.Equal(t, snapshotter.GetDelta(), snapshotter.GetSnapshot())
 	res, err := http.Get(requestUrl)
 	assert.NotNil(t, res)
 	assert.Equal(t, http.StatusOK, res.StatusCode)
@@ -334,7 +335,7 @@ func TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta(t 
 
 	var agentConfig config.AgentConfig
 	agentConfig.SetDefaults()
-	var snapshotter Snapshotter
+	var snapshotter snapshot.Snapshotter
 	envoyStatsHandler := buildHandlerWithSnapshotter(agentConfig, &snapshotter)
 
 	// Update EnvoyServer info to honor the mock Envoy server
@@ -354,8 +355,8 @@ func TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta(t 
 	snapshotter.HttpRequest, err = client.CreateRetryableAgentRequest(http.MethodGet, statsUrl, nil)
 	assert.NoError(t, err)
 	// Make two snapshots, then compute
-	snapshotter.makeSnapshot()
-	snapshotter.makeSnapshot()
+	MakeSnapshot(&snapshotter)
+	MakeSnapshot(&snapshotter)
 
 	filterParam := fmt.Sprintf("%s=%s", filterQueryKey, QuerySet[filterQueryKey])
 	requestUrl := fmt.Sprintf("%s?%s&%s&%s", statsServer.URL, filterParam, usedOnlyQueryKey, deltaQueryKey)
@@ -387,7 +388,7 @@ func TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_Ne
 
 	var agentConfig config.AgentConfig
 	agentConfig.SetDefaults()
-	var snapshotter Snapshotter
+	var snapshotter snapshot.Snapshotter
 	envoyStatsHandler := buildHandlerWithSnapshotter(agentConfig, &snapshotter)
 
 	// Update EnvoyServer info to honor the mock Envoy server
@@ -407,8 +408,8 @@ func TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_Ne
 	snapshotter.HttpRequest, err = client.CreateRetryableAgentRequest(http.MethodGet, statsUrl, nil)
 	assert.NoError(t, err)
 	// Make two snapshots, then compute, here making snapshot would indirectly call the Envoy stats handler
-	snapshotter.makeSnapshot()
-	snapshotter.makeSnapshot()
+	MakeSnapshot(&snapshotter)
+	MakeSnapshot(&snapshotter)
 
 	filterParam := fmt.Sprintf("%s=%s", filterQueryKey, QuerySet[filterQueryKey])
 	requestUrl := fmt.Sprintf("%s?%s&%s&%s", statsServer.URL, filterParam, usedOnlyQueryKey, deltaQueryKey)

--- a/agent/stats/snapshot/snapshotter.go
+++ b/agent/stats/snapshot/snapshotter.go
@@ -1,0 +1,61 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package snapshot
+
+import (
+	"sync"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/prometheus/client_model/go"
+	log "github.com/sirupsen/logrus"
+)
+
+type Snapshotter struct {
+	snapshot    map[string]*io_prometheus_client.MetricFamily
+	delta       map[string]*io_prometheus_client.MetricFamily
+	mutex       sync.RWMutex
+	HttpClient  *retryablehttp.Client
+	HttpRequest *retryablehttp.Request
+}
+
+func (snapshotter *Snapshotter) GetSnapshot() map[string]*io_prometheus_client.MetricFamily {
+	snapshotter.mutex.RLock()
+	defer snapshotter.mutex.RUnlock()
+	return snapshotter.snapshot
+}
+
+func (snapshotter *Snapshotter) SetSnapshot(snapshot map[string]*io_prometheus_client.MetricFamily) {
+	snapshotter.mutex.Lock()
+	defer snapshotter.mutex.Unlock()
+	snapshotter.snapshot = snapshot
+}
+
+// ResetSnapshot clears the previous snapshot so the next delta computation treats
+// the next snapshot as the first one.
+func (snapshotter *Snapshotter) ResetSnapshot() {
+	snapshotter.SetSnapshot(nil)
+	log.Info("Snapshot reset due to Envoy process exit.")
+}
+
+func (snapshotter *Snapshotter) GetDelta() map[string]*io_prometheus_client.MetricFamily {
+	snapshotter.mutex.RLock()
+	defer snapshotter.mutex.RUnlock()
+	return snapshotter.delta
+}
+
+func (snapshotter *Snapshotter) SetDelta(delta map[string]*io_prometheus_client.MetricFamily) {
+	snapshotter.mutex.Lock()
+	defer snapshotter.mutex.Unlock()
+	snapshotter.delta = delta
+}

--- a/agent/stats/snapshot/snapshotter_test.go
+++ b/agent/stats/snapshot/snapshotter_test.go
@@ -1,0 +1,152 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package snapshot
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+func makeMetricFamily(name string, value float64) map[string]*io_prometheus_client.MetricFamily {
+	metricName := name
+	metricType := io_prometheus_client.MetricType_COUNTER
+	return map[string]*io_prometheus_client.MetricFamily{
+		name: {
+			Name: &metricName,
+			Type: &metricType,
+			Metric: []*io_prometheus_client.Metric{
+				{Counter: &io_prometheus_client.Counter{Value: proto.Float64(value)}},
+			},
+		},
+	}
+}
+
+func TestGetSetSnapshot(t *testing.T) {
+	snapshotter := Snapshotter{}
+	assert.Nil(t, snapshotter.GetSnapshot())
+
+	snapshot := makeMetricFamily("RequestCount", 10)
+	snapshotter.SetSnapshot(snapshot)
+	assert.Equal(t, snapshot, snapshotter.GetSnapshot())
+}
+
+func TestGetSetDelta(t *testing.T) {
+	snapshotter := Snapshotter{}
+	assert.Nil(t, snapshotter.GetDelta())
+
+	delta := makeMetricFamily("RequestCount", 5)
+	snapshotter.SetDelta(delta)
+	assert.Equal(t, delta, snapshotter.GetDelta())
+}
+
+func TestResetSnapshot(t *testing.T) {
+	snapshotter := Snapshotter{}
+
+	snapshot := makeMetricFamily("RequestCount", 10)
+	snapshotter.SetSnapshot(snapshot)
+	assert.NotNil(t, snapshotter.GetSnapshot())
+
+	snapshotter.ResetSnapshot()
+	assert.Nil(t, snapshotter.GetSnapshot())
+}
+
+func TestConcurrentReadWrite(t *testing.T) {
+	snapshotter := Snapshotter{}
+	var waitGroup sync.WaitGroup
+
+	// Concurrent writers
+	for i := 0; i < 10; i++ {
+		waitGroup.Add(1)
+		go func(val float64) {
+			defer waitGroup.Done()
+			snapshotter.SetSnapshot(makeMetricFamily("RequestCount", val))
+			snapshotter.SetDelta(makeMetricFamily("RequestCount", val))
+		}(float64(i))
+	}
+
+	// Concurrent readers that verify returned values are complete and valid
+	for i := 0; i < 10; i++ {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			if snap := snapshotter.GetSnapshot(); snap != nil {
+				metricFamily := snap["RequestCount"]
+				assert.NotNil(t, metricFamily)
+				assert.NotNil(t, metricFamily.Name)
+				assert.Equal(t, "RequestCount", metricFamily.GetName())
+				assert.Equal(t, 1, len(metricFamily.Metric))
+				assert.NotNil(t, metricFamily.Metric[0].Counter)
+				val := metricFamily.Metric[0].Counter.GetValue()
+				assert.True(t, val >= 0 && val <= 9, "snapshot counter should be between 0 and 9, got %f", val)
+			}
+			if delta := snapshotter.GetDelta(); delta != nil {
+				metricFamily := delta["RequestCount"]
+				assert.NotNil(t, metricFamily)
+				assert.NotNil(t, metricFamily.Name)
+				assert.Equal(t, "RequestCount", metricFamily.GetName())
+				assert.Equal(t, 1, len(metricFamily.Metric))
+				assert.NotNil(t, metricFamily.Metric[0].Counter)
+				val := metricFamily.Metric[0].Counter.GetValue()
+				assert.True(t, val >= 0 && val <= 9, "delta counter should be between 0 and 9, got %f", val)
+			}
+		}()
+	}
+
+	waitGroup.Wait()
+
+	// After all goroutines finish, both snapshot and delta must be non-nil and hold valid values
+	snap := snapshotter.GetSnapshot()
+	assert.NotNil(t, snap)
+	snapVal := snap["RequestCount"].Metric[0].Counter.GetValue()
+	assert.True(t, snapVal >= 0 && snapVal <= 9, "final snapshot counter should be between 0 and 9, got %f", snapVal)
+
+	delta := snapshotter.GetDelta()
+	assert.NotNil(t, delta)
+	deltaVal := delta["RequestCount"].Metric[0].Counter.GetValue()
+	assert.True(t, deltaVal >= 0 && deltaVal <= 9, "final delta counter should be between 0 and 9, got %f", deltaVal)
+}
+
+func TestConcurrentReset(t *testing.T) {
+	snapshotter := Snapshotter{}
+	var waitGroup sync.WaitGroup
+
+	// Set an initial snapshot
+	snapshotter.SetSnapshot(makeMetricFamily("RequestCount", 100))
+	snapshotter.SetDelta(makeMetricFamily("RequestCount", 50))
+
+	// Concurrent resets
+	for i := 0; i < 10; i++ {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			snapshotter.ResetSnapshot()
+		}()
+	}
+
+	waitGroup.Wait()
+
+	// After all resets, snapshot must be nil
+	assert.Nil(t, snapshotter.GetSnapshot())
+	// Delta should be unaffected by ResetSnapshot
+	assert.NotNil(t, snapshotter.GetDelta())
+	assert.Equal(t, float64(50), snapshotter.GetDelta()["RequestCount"].Metric[0].Counter.GetValue())
+
+	// Set a new snapshot after reset and verify it's not contaminated by the old value
+	snapshotter.SetSnapshot(makeMetricFamily("RequestCount", 5))
+	assert.Equal(t, float64(5), snapshotter.GetSnapshot()["RequestCount"].Metric[0].Counter.GetValue())
+}

--- a/agent/stats/snapshots.go
+++ b/agent/stats/snapshots.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/aws/aws-app-mesh-agent/agent/client"
 	"github.com/aws/aws-app-mesh-agent/agent/config"
+	"github.com/aws/aws-app-mesh-agent/agent/stats/snapshot"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/prometheus/client_model/go"
@@ -29,21 +30,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-type Snapshotter struct {
-	Snapshot    map[string]*io_prometheus_client.MetricFamily
-	Delta       map[string]*io_prometheus_client.MetricFamily
-	HttpClient  *retryablehttp.Client
-	HttpRequest *retryablehttp.Request
-}
-
-// ResetSnapshot clears the previous snapshot so the next delta computation treats
-// the next snapshot as the first one.
-func (snapshotter *Snapshotter) ResetSnapshot() {
-	snapshotter.Snapshot = nil
-	log.Info("Snapshot reset due to Envoy process exit.")
-}
-
-func (snapshotter *Snapshotter) StartSnapshot(agentConfig config.AgentConfig) {
+func StartSnapshot(snapshotter *snapshot.Snapshotter, agentConfig config.AgentConfig) {
 	httpClient, err := client.CreateRetryableHttpClientForEnvoyServer(agentConfig)
 	httpClient.HTTPClient.Timeout = EnvoyStatsClientHttpTimeout
 	if err != nil {
@@ -68,28 +55,28 @@ func (snapshotter *Snapshotter) StartSnapshot(agentConfig config.AgentConfig) {
 	for {
 		select {
 		case <-ticker.C:
-			snapshotter.makeSnapshot()
+			MakeSnapshot(snapshotter)
 		}
 	}
 }
 
-// makeSnapshot capture snapshots once invoked, it will automatically compute delta once we have enough snapshots.
+// MakeSnapshot capture snapshots once invoked, it will automatically compute delta once we have enough snapshots.
 // The newly captured snapshot will be saved to snapshotter.
-func (snapshotter *Snapshotter) makeSnapshot() {
+func MakeSnapshot(snapshotter *snapshot.Snapshotter) {
 	statsBody, err := getStatsFromEnvoy(snapshotter.HttpClient, snapshotter.HttpRequest)
 	if err != nil {
 		log.Errorf("failed to get stats from Envoy, error: %v", err)
 		return
 	}
-	snapshot, err := processPrometheusStats(statsBody)
+	newSnapshot, err := processPrometheusStats(statsBody)
 	if err != nil {
 		log.Errorf("error processing Prometheus stats: %v", err)
 		return
 	}
-	if snapshot != nil {
+	if newSnapshot != nil {
 		// We will compute the delta and then save or overwrite the newly captured snapshot.
-		snapshotter.computeDelta(snapshot)
-		snapshotter.Snapshot = snapshot
+		computeDelta(snapshotter, newSnapshot)
+		snapshotter.SetSnapshot(newSnapshot)
 	}
 }
 
@@ -99,15 +86,16 @@ func (snapshotter *Snapshotter) makeSnapshot() {
 //
 // The dependency library does not support protobuf v2 APIs. See their README: https://github.com/prometheus/client_model
 // Possibly switching to OpenMetrics(https://openmetrics.io/) when it is ready in the future.
-func (snapshotter *Snapshotter) computeDelta(newSnapshot map[string]*io_prometheus_client.MetricFamily) {
+func computeDelta(snapshotter *snapshot.Snapshotter, newSnapshot map[string]*io_prometheus_client.MetricFamily) {
 	if newSnapshot == nil {
 		log.Errorf("the newSnapshot should exist to compute the snapshot")
 		return
 	}
 
-	if snapshotter.Snapshot == nil {
+	currentSnapshot := snapshotter.GetSnapshot()
+	if currentSnapshot == nil {
 		log.Debugf("Using the new snapshot as delta since there is no previously captured snapshot yet.")
-		snapshotter.Delta = newSnapshot
+		snapshotter.SetDelta(newSnapshot)
 		return
 	}
 
@@ -116,14 +104,14 @@ func (snapshotter *Snapshotter) computeDelta(newSnapshot map[string]*io_promethe
 		// It is possible that there are new metrics emitted in the new snapshot, in which case the old snapshot won't
 		// have the corresponding metrics. This would result in metricFamilyKey does not exist in the existing snapshot,
 		// in which case the oldMetricFamily passed in would simply be nil.
-		snapshotter.computeDeltaForMetricFamily(snapshotter.Snapshot[metricFamilyKey], newMetricFamily, newDelta)
+		computeDeltaForMetricFamily(currentSnapshot[metricFamilyKey], newMetricFamily, newDelta)
 
 	}
 	// We only update Delta once the new delta is completely computed.
-	snapshotter.Delta = newDelta
+	snapshotter.SetDelta(newDelta)
 }
 
-func (snapshotter *Snapshotter) computeDeltaForMetricFamily(oldMetricFamily, newMetricFamily *io_prometheus_client.MetricFamily, delta map[string]*io_prometheus_client.MetricFamily) {
+func computeDeltaForMetricFamily(oldMetricFamily, newMetricFamily *io_prometheus_client.MetricFamily, delta map[string]*io_prometheus_client.MetricFamily) {
 	if oldMetricFamily == nil && newMetricFamily == nil {
 		log.Error("both metric families are empty, cannot compute delta")
 		return
@@ -246,7 +234,7 @@ func generateMetricKey(labels []*io_prometheus_client.LabelPair) string {
 	return metricKey
 }
 
-// Util function for snapshotter to call Envoy Stats endpoint
+// Util function for calling Envoy Stats endpoint
 func getStatsFromEnvoy(httpClient *retryablehttp.Client, request *retryablehttp.Request) ([]byte, error) {
 	// Send request to Envoy Stats endpoint
 	start := time.Now()

--- a/agent/stats/snapshots_test.go
+++ b/agent/stats/snapshots_test.go
@@ -14,11 +14,13 @@
 package stats
 
 import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-app-mesh-agent/agent/stats/snapshot"
 	"github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 func TestComputeDeltaForMetricFamily(t *testing.T) {
@@ -43,9 +45,8 @@ func TestComputeDeltaForMetricFamily(t *testing.T) {
 	assert.True(t, ok)
 
 	// Manually call computeDelta
-	snapshotter := Snapshotter{}
 	delta := make(map[string]*io_prometheus_client.MetricFamily)
-	snapshotter.computeDeltaForMetricFamily(metricFamily1, metricFamily2, delta)
+	computeDeltaForMetricFamily(metricFamily1, metricFamily2, delta)
 	assert.NotNil(t, delta)
 
 	// Examine the delta to make sure it is correctly computed
@@ -79,7 +80,7 @@ func TestComputeDeltaForMetricFamily(t *testing.T) {
 
 	// Manually call computeDelta
 	delta = make(map[string]*io_prometheus_client.MetricFamily)
-	snapshotter.computeDeltaForMetricFamily(metricFamily1, metricFamily2, delta)
+	computeDeltaForMetricFamily(metricFamily1, metricFamily2, delta)
 	assert.NotNil(t, delta)
 
 	// Examine the delta to make sure it is correctly computed
@@ -125,7 +126,7 @@ func TestComputeDeltaForMetricFamily(t *testing.T) {
 
 	// Compute Delta
 	delta = make(map[string]*io_prometheus_client.MetricFamily)
-	snapshotter.computeDeltaForMetricFamily(metricFamily1, metricFamily2, delta)
+	computeDeltaForMetricFamily(metricFamily1, metricFamily2, delta)
 
 	assert.NotNil(t, delta)
 	deltaMetricFamily, ok = delta[name]
@@ -173,7 +174,7 @@ func TestComputeDeltaForMetricFamily(t *testing.T) {
 
 	// Manually call computeDelta
 	delta = make(map[string]*io_prometheus_client.MetricFamily)
-	snapshotter.computeDeltaForMetricFamily(metricFamily1, metricFamily2, delta)
+	computeDeltaForMetricFamily(metricFamily1, metricFamily2, delta)
 	assert.NotNil(t, delta)
 
 	// Examine the delta to make sure it is correctly computed
@@ -186,30 +187,30 @@ func TestComputeDeltaForMetricFamily(t *testing.T) {
 }
 
 func TestResetSnapshot(t *testing.T) {
-	snapshotter := Snapshotter{}
+	snapshotter := snapshot.Snapshotter{}
 
 	input1 := []byte("# TYPE RequestCount counter\n" +
 		"RequestCount{Service=\"svc\"} 10\n")
 	snapshot1, err := parsePrometheusStats(input1)
 	assert.NoError(t, err)
 
-	snapshotter.computeDelta(snapshot1)
-	snapshotter.Snapshot = snapshot1
-	assert.NotNil(t, snapshotter.Snapshot)
-	assert.NotNil(t, snapshotter.Delta)
+	computeDelta(&snapshotter, snapshot1)
+	snapshotter.SetSnapshot(snapshot1)
+	assert.NotNil(t, snapshotter.GetSnapshot())
+	assert.NotNil(t, snapshotter.GetDelta())
 
 	input2 := []byte("# TYPE RequestCount counter\n" +
 		"RequestCount{Service=\"svc\"} 20\n")
 	snapshot2, err := parsePrometheusStats(input2)
 	assert.NoError(t, err)
 
-	snapshotter.computeDelta(snapshot2)
-	snapshotter.Snapshot = snapshot2
-	assert.Equal(t, float64(10), snapshotter.Delta["RequestCount"].Metric[0].Counter.GetValue())
+	computeDelta(&snapshotter, snapshot2)
+	snapshotter.SetSnapshot(snapshot2)
+	assert.Equal(t, float64(10), snapshotter.GetDelta()["RequestCount"].Metric[0].Counter.GetValue())
 
 	// Envoy dies, ResetSnapshot is called before new Envoy starts
 	snapshotter.ResetSnapshot()
-	assert.Nil(t, snapshotter.Snapshot)
+	assert.Nil(t, snapshotter.GetSnapshot())
 
 	// New Envoy starts, counters reset to zero
 	input3 := []byte("# TYPE RequestCount counter\n" +
@@ -217,15 +218,15 @@ func TestResetSnapshot(t *testing.T) {
 	snapshot3, err := parsePrometheusStats(input3)
 	assert.NoError(t, err)
 
-	snapshotter.computeDelta(snapshot3)
-	snapshotter.Snapshot = snapshot3
+	computeDelta(&snapshotter, snapshot3)
+	snapshotter.SetSnapshot(snapshot3)
 
 	// Delta should be 5 (the raw new value), not 5 - 20 = -15
-	assert.Equal(t, float64(5), snapshotter.Delta["RequestCount"].Metric[0].Counter.GetValue())
+	assert.Equal(t, float64(5), snapshotter.GetDelta()["RequestCount"].Metric[0].Counter.GetValue())
 }
 
 func TestResetSnapshotHistogram(t *testing.T) {
-	snapshotter := Snapshotter{}
+	snapshotter := snapshot.Snapshotter{}
 
 	input1 := []byte("# TYPE TargetResponseTime histogram\n" +
 		"TargetResponseTime_bucket{Service=\"svc\",le=\"5\"} 30\n" +
@@ -235,12 +236,12 @@ func TestResetSnapshotHistogram(t *testing.T) {
 	snapshot1, err := parsePrometheusStats(input1)
 	assert.NoError(t, err)
 
-	snapshotter.computeDelta(snapshot1)
-	snapshotter.Snapshot = snapshot1
+	computeDelta(&snapshotter, snapshot1)
+	snapshotter.SetSnapshot(snapshot1)
 
 	// Envoy dies, ResetSnapshot is called
 	snapshotter.ResetSnapshot()
-	assert.Nil(t, snapshotter.Snapshot)
+	assert.Nil(t, snapshotter.GetSnapshot())
 
 	// New Envoy starts with reset counters
 	input2 := []byte("# TYPE TargetResponseTime histogram\n" +
@@ -251,11 +252,11 @@ func TestResetSnapshotHistogram(t *testing.T) {
 	snapshot2, err := parsePrometheusStats(input2)
 	assert.NoError(t, err)
 
-	snapshotter.computeDelta(snapshot2)
-	snapshotter.Snapshot = snapshot2
+	computeDelta(&snapshotter, snapshot2)
+	snapshotter.SetSnapshot(snapshot2)
 
 	name := "TargetResponseTime"
-	histogram := snapshotter.Delta[name].Metric[0].Histogram
+	histogram := snapshotter.GetDelta()[name].Metric[0].Histogram
 
 	// All values should be the raw new values, not deltas against the old snapshot
 	assert.Equal(t, uint64(3), histogram.Bucket[0].GetCumulativeCount())


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Add thread-safe access to the stats snapshotter by encapsulating its internal state behind synchronized getters and setters, preventing data races between the snapshot ticker goroutine and the HTTP handler.

Previously, the snapshot and delta fields on the snapshotter struct were exported and accessed without synchronization from multiple goroutines: the snapshot ticker writes both fields periodically, the HTTP handler reads delta when serving delta requests, and the Envoy process monitor resets dnapshot on restart. These concurrent unsynchronized reads and writes constitute data races in Go, which can lead to corrupted reads, panics from concurrent map access, or undefined behavior.

### Implementation details
<!-- How are the changes implemented? -->
- Extracted the snapshotter struct into a stats/snapshot sub-package with unexported fields protected by a mutex lock. All access goes through exported getter/setter methods, enforced at the package boundary by the compiler.
- Updated callers to use the new type and read snapshot/delta values once per operation instead of multiple times.

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
Please ensure unit and integration tests pass (on at least one platform) before opening the pull request.
Once you open the pull request, there will be several automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it.
-->
```
./docker-build.sh

=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success
time="2026-04-15T18:04:07Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Envoy Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Failure_Envoy_Internal_Error
time="2026-04-15T18:04:07Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Envoy Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Agent Environment Variables: []"
time="2026-04-15T18:04:07Z" level=error msg="Call to fetch stats from Envoy admin failed: giving up after 4 attempt(s): status: 502 Bad Gateway"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Failure_Envoy_Internal_Error (0.70s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Usedonly
time="2026-04-15T18:04:07Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Envoy Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Usedonly (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Failure_QueryParameter_Unsupported_Param
time="2026-04-15T18:04:07Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Envoy Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Failure_QueryParameter_Unsupported_Param (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Metrics_Filtering_and_Sorting
time="2026-04-15T18:04:07Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Envoy Environment Variables: [ENVOY_ADMIN_MODE=tcp]"
time="2026-04-15T18:04:07Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Metrics_Filtering_and_Sorting (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_SingleSnapshot
time="2026-04-15T18:04:07Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Envoy Environment Variables: [ENVOY_ADMIN_MODE=tcp]"
time="2026-04-15T18:04:07Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_SingleSnapshot (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta
time="2026-04-15T18:04:07Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Envoy Environment Variables: [ENVOY_ADMIN_MODE=tcp]"
time="2026-04-15T18:04:07Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_NewMetrics
time="2026-04-15T18:04:07Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:07Z" level=info msg="Envoy Environment Variables: [ENVOY_ADMIN_MODE=tcp]"
time="2026-04-15T18:04:07Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_NewMetrics (0.00s)
=== RUN   TestParsePrometheusStats
--- PASS: TestParsePrometheusStats (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_ValidateGetStatsRequest_Bad_Request
--- PASS: TestEnvoyPrometheusStatsHandler_ValidateGetStatsRequest_Bad_Request (0.00s)
=== RUN   TestComputeDeltaForMetricFamily
--- PASS: TestComputeDeltaForMetricFamily (0.00s)
=== RUN   TestResetSnapshot
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
--- PASS: TestResetSnapshot (0.00s)
=== RUN   TestResetSnapshotHistogram
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
--- PASS: TestResetSnapshotHistogram (0.00s)
PASS
ok      github.com/aws/aws-app-mesh-agent/agent/stats   0.717s
=== RUN   TestGetSetSnapshot
--- PASS: TestGetSetSnapshot (0.00s)
=== RUN   TestGetSetDelta
--- PASS: TestGetSetDelta (0.00s)
=== RUN   TestResetSnapshot
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
--- PASS: TestResetSnapshot (0.00s)
=== RUN   TestConcurrentReadWrite
--- PASS: TestConcurrentReadWrite (0.00s)
=== RUN   TestConcurrentReset
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:07Z" level=info msg="Snapshot reset due to Envoy process exit."
--- PASS: TestConcurrentReset (0.00s)
PASS
ok      github.com/aws/aws-app-mesh-agent/agent/stats/snapshot  0.004s
GOPATH=/build
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -mod=vendor -ldflags "-w -s"
```

Also ran tests against race detection target:
```
./docker-build.sh test-race

=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success
time="2026-04-15T18:04:57Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Envoy Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Failure_Envoy_Internal_Error
time="2026-04-15T18:04:57Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Envoy Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Agent Environment Variables: []"
time="2026-04-15T18:04:57Z" level=error msg="Call to fetch stats from Envoy admin failed: giving up after 4 attempt(s): status: 502 Bad Gateway"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Failure_Envoy_Internal_Error (0.71s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Usedonly
time="2026-04-15T18:04:57Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Envoy Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Usedonly (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Failure_QueryParameter_Unsupported_Param
time="2026-04-15T18:04:57Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Envoy Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Failure_QueryParameter_Unsupported_Param (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Metrics_Filtering_and_Sorting
time="2026-04-15T18:04:57Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Envoy Environment Variables: [ENVOY_ADMIN_MODE=tcp]"
time="2026-04-15T18:04:57Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Metrics_Filtering_and_Sorting (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_SingleSnapshot
time="2026-04-15T18:04:57Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Envoy Environment Variables: [ENVOY_ADMIN_MODE=tcp]"
time="2026-04-15T18:04:57Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_SingleSnapshot (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta
time="2026-04-15T18:04:57Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Envoy Environment Variables: [ENVOY_ADMIN_MODE=tcp]"
time="2026-04-15T18:04:57Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_NewMetrics
time="2026-04-15T18:04:57Z" level=info msg="App Mesh Environment Variables: []"
time="2026-04-15T18:04:57Z" level=info msg="Envoy Environment Variables: [ENVOY_ADMIN_MODE=tcp]"
time="2026-04-15T18:04:57Z" level=info msg="Agent Environment Variables: []"
--- PASS: TestEnvoyPrometheusStatsHandler_HandleStats_Success_QueryParameter_Delta_NewMetrics (0.00s)
=== RUN   TestParsePrometheusStats
--- PASS: TestParsePrometheusStats (0.00s)
=== RUN   TestEnvoyPrometheusStatsHandler_ValidateGetStatsRequest_Bad_Request
--- PASS: TestEnvoyPrometheusStatsHandler_ValidateGetStatsRequest_Bad_Request (0.00s)
=== RUN   TestComputeDeltaForMetricFamily
--- PASS: TestComputeDeltaForMetricFamily (0.00s)
=== RUN   TestResetSnapshot
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
--- PASS: TestResetSnapshot (0.00s)
=== RUN   TestResetSnapshotHistogram
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
--- PASS: TestResetSnapshotHistogram (0.00s)
PASS
ok      github.com/aws/aws-app-mesh-agent/agent/stats   1.741s
=== RUN   TestGetSetSnapshot
--- PASS: TestGetSetSnapshot (0.00s)
=== RUN   TestGetSetDelta
--- PASS: TestGetSetDelta (0.00s)
=== RUN   TestResetSnapshot
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
--- PASS: TestResetSnapshot (0.00s)
=== RUN   TestConcurrentReadWrite
--- PASS: TestConcurrentReadWrite (0.00s)
=== RUN   TestConcurrentReset
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
time="2026-04-15T18:04:57Z" level=info msg="Snapshot reset due to Envoy process exit."
--- PASS: TestConcurrentReset (0.00s)
PASS
ok      github.com/aws/aws-app-mesh-agent/agent/stats/snapshot  1.015s
```

New tests cover the changes: Yes, new unit tests added in snapshotter_test.go.
- TestGetSetSnapshot: Verifies getting/setting for snapshots.
- TestGetSetDelta: Verifies getting/setting for deltas.
- TestResetSnapshot: Verifies ResetSnapshot clears snapshot to nil.
- TestConcurrentReadWrite: Concurrent writers set different values while concurrent readers verify structural completeness of returned metric families; Validates no data races or partial writes under contention.
- TestConcurrentReset: Concurrent resets run alongside verification that snapshot is nil afterward, delta is unaffected, and a new snapshot after reset holds the correct value without contamination from the old one.

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Fix race condition on snapshotter snapshot/delta fields by moving struct to sub-package with mutex-protected getters/setters.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.