### PR TITLE
Add code coverage check on build with 70% threshold

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -11,7 +11,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-.PHONY: build format test test-race go-build clean run vendor
+.PHONY: build format test test-race go-build clean run vendor coverage
 
 OSARCH = $(shell arch)
 ifeq ($(OSARCH), x86_64)
@@ -38,7 +38,10 @@ SRCS := $(wildcard *.go) \
 	$(wildcard client/*.go) \
 	$(wildcard stats/*.go) \
 
-build: test go-build
+COVERAGE_THRESHOLD ?= 70
+COVERAGE_FILE := coverage.out
+
+build: coverage go-build
 
 vendor:
 	go mod vendor
@@ -48,6 +51,15 @@ format: $(SRCS)
 
 test: $(SRCS) format
 	go test -mod=vendor -count=1 -v ./...
+
+coverage: $(SRCS) format
+	go test -mod=vendor -count=1 -coverprofile=$(COVERAGE_FILE) ./...
+	@COVERAGE=$$(go tool cover -func=$(COVERAGE_FILE) | grep total | awk '{print $$3}' | tr -d '%'); \
+	echo "Total coverage: $${COVERAGE}%"; \
+	if [ $$(echo "$${COVERAGE} < $(COVERAGE_THRESHOLD)" | bc) -eq 1 ]; then \
+		echo "FAIL: Coverage $${COVERAGE}% is below threshold $(COVERAGE_THRESHOLD)%"; \
+		exit 1; \
+	fi
 
 test-race: $(SRCS) format
 	go test -mod=vendor -count=1 -race -v ./...


### PR DESCRIPTION
### Summary
Add code coverage enforcement to the build process. Running `make build` now measures test coverage and fails if it drops below a configurable threshold (default: 70%).

### Implementation details
- Added a `coverage` target to the Makefile that runs `go test` with `-coverprofile`, parses the aggregate coverage using `go tool cover -func`, and fails the build if coverage is below `COVERAGE_THRESHOLD`.
- Changed the `build` target dependency from `test` to `coverage` so every build enforces the coverage gate.
- The threshold defaults to 70% (based on current coverage of ~74.6%) and is overridable via `make build COVERAGE_THRESHOLD=<value>`.
- The existing `test` target is preserved for running tests without coverage enforcement.

### Testing
- Ran `make -n build` (dry-run) to verify correct Makefile syntax and target chaining.
- Ran `go test -coverprofile=coverage.out ./...` to confirm coverage profiling works and measured current aggregate coverage at 74.6%.
- Verified the threshold check logic correctly fails when coverage is below the threshold and passes when above.

New tests cover the changes: no

### Description for the changelog
Add code coverage check on build with a configurable threshold (default 70%).

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.