### PR TITLE
Read NAMESPACE_NAME env var into Envoy bootstrap node metadata

### DIFF
--- a/agent/envoy_bootstrap/envoy_bootstrap.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap.go
@@ -38,6 +38,7 @@ import (
 	"github.com/aws/aws-app-mesh-agent/agent/envoy_bootstrap/metric_filter"
 	"github.com/aws/aws-app-mesh-agent/agent/envoy_bootstrap/netinfo"
 	"github.com/aws/aws-app-mesh-agent/agent/envoy_bootstrap/platforminfo"
+	"github.com/aws/aws-app-mesh-agent/agent/envoy_bootstrap/servicediscovery"
 	sdkConfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/aws/aws-xray-sdk-go/strategy/sampling"
@@ -1479,6 +1480,15 @@ func buildMetadataForNode() (*structpb.Struct, error) {
 		log.Warnf("Could not collect listener info: %v", err)
 	} else {
 		for k, v := range listenerInfo {
+			metadata[k] = v
+		}
+	}
+
+	serviceDiscovery, err := servicediscovery.BuildMetadata()
+	if err != nil {
+		log.Warnf("Could not collect service discovery info: %v", err)
+	} else {
+		for k, v := range serviceDiscovery {
 			metadata[k] = v
 		}
 	}

--- a/agent/envoy_bootstrap/envoy_bootstrap_test.go
+++ b/agent/envoy_bootstrap/envoy_bootstrap_test.go
@@ -681,6 +681,24 @@ metadata:
 `)
 }
 
+func TestBuildNodeMetadata_ServiceDiscovery(t *testing.T) {
+	setup()
+	os.Setenv("NAMESPACE_NAME", "my-namespace")
+	os.Setenv("NAMESPACE_ARN", "arn:aws:servicediscovery:us-west-2:123456789012:namespace/ns-12345")
+	defer os.Unsetenv("NAMESPACE_NAME")
+	defer os.Unsetenv("NAMESPACE_ARN")
+	metadata, err := buildMetadataForNode()
+	assert.Nil(t, err)
+	checkMessageSupersetMatch(t, buildNode("id", "cluster", metadata), `
+id: id
+cluster: cluster
+metadata:
+  aws.ecs.serviceconnect.ServiceDiscovery:
+    NamespaceName: my-namespace
+    NamespaceArn: arn:aws:servicediscovery:us-west-2:123456789012:namespace/ns-12345
+`)
+}
+
 func TestBuildNodeMetadata_StaticRuntimeMappingDefault(t *testing.T) {
 	setup()
 	metadata, err := buildMetadataForNode()

--- a/agent/envoy_bootstrap/servicediscovery/service_discovery_collector.go
+++ b/agent/envoy_bootstrap/servicediscovery/service_discovery_collector.go
@@ -1,0 +1,52 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package servicediscovery
+
+import (
+	"github.com/aws/aws-app-mesh-agent/agent/envoy_bootstrap/env"
+)
+
+const (
+	metadataNamespace = "aws.ecs.serviceconnect.ServiceDiscovery"
+
+	namespaceNameEnvVar = "NAMESPACE_NAME"
+	namespaceArnEnvVar  = "NAMESPACE_ARN"
+
+	namespaceNameKey = "NamespaceName"
+	namespaceArnKey  = "NamespaceArn"
+)
+
+// BuildMetadata generates a metadata map containing the Cloud Map service
+// discovery namespace info (name and ARN) read from environment variables
+// set by RMS on the SC agent container.
+//
+// When neither env var is set, the returned map is empty and the
+// aws.ecs.serviceconnect.ServiceDiscovery key will not appear in the final
+// Envoy node metadata.
+func BuildMetadata() (map[string]interface{}, error) {
+	mapping := make(map[string]interface{})
+
+	if v := env.Get(namespaceNameEnvVar); v != "" {
+		mapping[namespaceNameKey] = v
+	}
+	if v := env.Get(namespaceArnEnvVar); v != "" {
+		mapping[namespaceArnKey] = v
+	}
+
+	metadata := map[string]interface{}{}
+	if len(mapping) > 0 {
+		metadata[metadataNamespace] = mapping
+	}
+	return metadata, nil
+}

--- a/agent/envoy_bootstrap/servicediscovery/service_discovery_collector_test.go
+++ b/agent/envoy_bootstrap/servicediscovery/service_discovery_collector_test.go
@@ -1,0 +1,129 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package servicediscovery
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testNamespaceName = "test-namespace"
+	testNamespaceArn  = "arn:aws:servicediscovery:us-west-2:123456789012:namespace/ns-12345"
+)
+
+func setup() {
+	os.Clearenv()
+}
+
+func TestBuildMetadata(t *testing.T) {
+	tests := []struct {
+		name                 string
+		setEnvVars           map[string]string // env vars to set; absent key = unset
+		expectedKeys         map[string]string // expected metadata keys; absent key = should not appear
+		setMetadataNamespace bool              // whether the top-level ServiceDiscovery namespace is emitted
+	}{
+		{
+			name: "both set",
+			setEnvVars: map[string]string{
+				namespaceNameEnvVar: testNamespaceName,
+				namespaceArnEnvVar:  testNamespaceArn,
+			},
+			expectedKeys: map[string]string{
+				namespaceNameKey: testNamespaceName,
+				namespaceArnKey:  testNamespaceArn,
+			},
+			setMetadataNamespace: true,
+		},
+		{
+			name:                 "only name set",
+			setEnvVars:           map[string]string{namespaceNameEnvVar: testNamespaceName},
+			expectedKeys:         map[string]string{namespaceNameKey: testNamespaceName},
+			setMetadataNamespace: true,
+		},
+		{
+			name: "name set, arn empty",
+			setEnvVars: map[string]string{
+				namespaceNameEnvVar: testNamespaceName,
+				namespaceArnEnvVar:  "",
+			},
+			expectedKeys:         map[string]string{namespaceNameKey: testNamespaceName},
+			setMetadataNamespace: true,
+		},
+		{
+			name:                 "only arn set",
+			setEnvVars:           map[string]string{namespaceArnEnvVar: testNamespaceArn},
+			expectedKeys:         map[string]string{namespaceArnKey: testNamespaceArn},
+			setMetadataNamespace: true,
+		},
+		{
+			name: "name empty, arn set",
+			setEnvVars: map[string]string{
+				namespaceNameEnvVar: "",
+				namespaceArnEnvVar:  testNamespaceArn,
+			},
+			expectedKeys:         map[string]string{namespaceArnKey: testNamespaceArn},
+			setMetadataNamespace: true,
+		},
+		{
+			name:                 "both unset",
+			setMetadataNamespace: false,
+		},
+		{
+			name:                 "name unset, arn empty",
+			setEnvVars:           map[string]string{namespaceArnEnvVar: ""},
+			setMetadataNamespace: false,
+		},
+		{
+			name:                 "name empty, arn unset",
+			setEnvVars:           map[string]string{namespaceNameEnvVar: ""},
+			setMetadataNamespace: false,
+		},
+		{
+			name: "both empty",
+			setEnvVars: map[string]string{
+				namespaceNameEnvVar: "",
+				namespaceArnEnvVar:  "",
+			},
+			setMetadataNamespace: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			setup()
+			for k, v := range tc.setEnvVars {
+				os.Setenv(k, v)
+				defer os.Unsetenv(k)
+			}
+
+			metadata, err := BuildMetadata()
+			assert.Nil(t, err)
+
+			mapping, ok := metadata[metadataNamespace].(map[string]interface{})
+			assert.Equal(t, tc.setMetadataNamespace, ok)
+			if !tc.setMetadataNamespace {
+				return
+			}
+
+			for key, expectedValue := range tc.expectedKeys {
+				assert.Equal(t, expectedValue, mapping[key], "key %q", key)
+			}
+			assert.Equal(t, len(tc.expectedKeys), len(mapping),
+				"unexpected extra keys in mapping: %v", mapping)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-service-connect-agent/blob/main/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Adds support for two new environment variables on the SC agent: NAMESPACE_NAME and NAMESPACE_ARN. The agent reads them at startup and adds them to the Envoy bootstrap config so that the Wasm extension running inside Envoy can use them to tag Service Connect metrics.

If either variable is unset or empty, that field is left out of the bootstrap.

### Implementation details
<!-- How are the changes implemented? -->
A new package agent/envoy_bootstrap/servicediscovery/ follows the same pattern as the other Service Connect collectors (applicationinfo, listenerinfo):

- It reads the two env vars and puts the values into a new top-level metadata key called aws.ecs.serviceconnect.ServiceDiscovery.
- It exports a small helper GetInfo(metadata, key) plus key constants for callers that need to read these values back from a parsed metadata struct.
- It's wired into buildMetadataForNode() in envoy_bootstrap.go next to the other collectors.

When both env vars are set, the resulting node metadata looks like:
```
metadata:
  ...
  aws.ecs.serviceconnect.ServiceDiscovery:
    NamespaceName: my-namespace
    NamespaceArn: arn:aws:servicediscovery:us-west-2:123456789012:namespace/ns-12345
```

### Testing
<!-- How was this tested? -->
<!--
Note for external contributors:
Please ensure unit and integration tests pass (on at least one platform) before opening the pull request.
Once you open the pull request, there will be several automatic test checks on the bottom
of the pull request, please make sure they all pass before you merge it.
-->
```
===== Targeted tests (ServiceDiscovery bootstrap + servicediscovery package) — verbose =====
=== RUN   TestBuildNodeMetadata_ServiceDiscovery
--- PASS: TestBuildNodeMetadata_ServiceDiscovery (0.00s)
PASS
ok  	github.com/aws/aws-app-mesh-agent/agent/envoy_bootstrap	0.011s
=== RUN   TestBuildMetadata_BothEnvVarsSet
--- PASS: TestBuildMetadata_BothEnvVarsSet (0.00s)
=== RUN   TestBuildMetadata_OnlyNamespaceName
--- PASS: TestBuildMetadata_OnlyNamespaceName (0.00s)
=== RUN   TestBuildMetadata_OnlyNamespaceArn
--- PASS: TestBuildMetadata_OnlyNamespaceArn (0.00s)
=== RUN   TestBuildMetadata_NeitherSet
--- PASS: TestBuildMetadata_NeitherSet (0.00s)
=== RUN   TestBuildMetadata_BothEmpty
--- PASS: TestBuildMetadata_BothEmpty (0.00s)
=== RUN   TestGetInfo_WithValidMetadata
--- PASS: TestGetInfo_WithValidMetadata (0.00s)
=== RUN   TestGetInfo_WithNilMetadata
--- PASS: TestGetInfo_WithNilMetadata (0.00s)
=== RUN   TestGetInfo_WithEmptyMetadata
--- PASS: TestGetInfo_WithEmptyMetadata (0.00s)
=== RUN   TestGetInfo_WithMissingServiceDiscoveryNamespace
--- PASS: TestGetInfo_WithMissingServiceDiscoveryNamespace (0.00s)
=== RUN   TestGetInfo_WithMissingKey
--- PASS: TestGetInfo_WithMissingKey (0.00s)
=== RUN   TestGetInfo_WithNonStringValue
--- PASS: TestGetInfo_WithNonStringValue (0.00s)
PASS
ok  	github.com/aws/aws-app-mesh-agent/agent/envoy_bootstrap/servicediscovery	0.004s

===== Full envoy_bootstrap package =====
ok  	github.com/aws/aws-app-mesh-agent/agent/envoy_bootstrap	0.042s

===== Full servicediscovery package =====
ok  	github.com/aws/aws-app-mesh-agent/agent/envoy_bootstrap/servicediscovery	0.004s

===== Both with -race =====
ok  	github.com/aws/aws-app-mesh-agent/agent/envoy_bootstrap	1.173s
ok  	github.com/aws/aws-app-mesh-agent/agent/envoy_bootstrap/servicediscovery	1.014s
```

New tests cover the changes: <!-- yes|no --> Yes

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
-->
Add Service Discovery namespace name and ARN to Envoy bootstrap node metadata.

### Licensing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
